### PR TITLE
Add option to set max requeues

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ OPTIONS:
         --report                     Enable reporter mode: do not pull tests off the queue; instead print build progress and exit when it's finished.
                                      Exits with a non-zero status code if there were any failures.
         --report-timeout N           Fail if build is not finished after N seconds. Only applicable if --report is enabled (default: 3600).
-        --max-requeues N             Set the number of times a failing spec will be requeued (default: 3).
+        --max-requeues N             Retry failed examples up to N times before considering them legit failures (default: 3).
     -h, --help                       Show this message.
     -v, --version                    Print the version and exit.
 ```

--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ OPTIONS:
         --report                     Enable reporter mode: do not pull tests off the queue; instead print build progress and exit when it's finished.
                                      Exits with a non-zero status code if there were any failures.
         --report-timeout N           Fail if build is not finished after N seconds. Only applicable if --report is enabled (default: 3600).
+        --max-requeues N             Set the number of times a failing spec will be requeued (default: 3).
     -h, --help                       Show this message.
     -v, --version                    Print the version and exit.
 ```
@@ -94,9 +95,9 @@ dynamically (see #3).
 
 As a mitigation technique against flaky tests, if an example fails it will be
 put back to the queue to be picked up by another worker. This will be repeated
-up to a certain number of times (set by `MAX_REQUEUES`), after which the example
-will be considered a legit failure and printed as such in the final
-report.
+up to a certain number of times (set with the `--max-requeues` option), after 
+which the example will be considered a legit failure and printed as such in the 
+final report.
 
 ### Worker failures
 

--- a/bin/rspecq
+++ b/bin/rspecq
@@ -4,7 +4,6 @@ require "rspecq"
 
 DEFAULT_REDIS_HOST = "127.0.0.1"
 DEFAULT_REPORT_TIMEOUT = 3600 # 1 hour
-DEFAULT_MAX_REQUEUES = 3
 
 def env_set?(var)
   ["1", "true"].include?(ENV[var])
@@ -66,8 +65,9 @@ OptionParser.new do |o|
     opts[:report_timeout] = v
   end
 
-  o.on("--max-requeues N", Integer, "Sets the number of max requeues to N " \
-       "times (default: #{DEFAULT_MAX_REQUEUES}).") do |v|
+  o.on("--max-requeues N", Integer, "Retry failed examples up to N times "   \
+       "before considering them legit failures "                             \
+       "(default: #{RSpecQ::DEFAULT_MAX_REQUEUES}).") do |v|
     opts[:max_requeues] = v
   end
 
@@ -89,7 +89,7 @@ opts[:timings] ||= env_set?("RSPECQ_UPDATE_TIMINGS")
 opts[:file_split_threshold] ||= Integer(ENV["RSPECQ_FILE_SPLIT_THRESHOLD"] || 9999999)
 opts[:report] ||= env_set?("RSPECQ_REPORT")
 opts[:report_timeout] ||= Integer(ENV["RSPECQ_REPORT_TIMEOUT"] || DEFAULT_REPORT_TIMEOUT)
-opts[:max_requeues] ||= Integer(ENV["MAX_REQUEUES"] || DEFAULT_MAX_REQUEUES)
+opts[:max_requeues] ||= Integer(ENV["RSPECQ_MAX_REQUEUES"] || RSpecQ::DEFAULT_MAX_REQUEUES)
 
 raise OptionParser::MissingArgument.new(:build) if opts[:build].nil?
 raise OptionParser::MissingArgument.new(:worker) if !opts[:report] && opts[:worker].nil?
@@ -108,10 +108,10 @@ else
     worker_id: opts[:worker],
     redis_host: opts[:redis_host],
     files_or_dirs_to_run: ARGV[0] || "spec",
-    max_requeues: opts[:max_requeues]
   )
 
   worker.populate_timings = opts[:timings]
   worker.file_split_threshold = opts[:file_split_threshold]
+  worker.max_requeues = opts[:max_requeues]
   worker.work
 end

--- a/bin/rspecq
+++ b/bin/rspecq
@@ -4,6 +4,7 @@ require "rspecq"
 
 DEFAULT_REDIS_HOST = "127.0.0.1"
 DEFAULT_REPORT_TIMEOUT = 3600 # 1 hour
+DEFAULT_MAX_REQUEUES = 3
 
 def env_set?(var)
   ["1", "true"].include?(ENV[var])
@@ -67,7 +68,7 @@ OptionParser.new do |o|
 
   o.on("--max-requeues N", Integer, "Retry failed examples up to N times "   \
        "before considering them legit failures "                             \
-       "(default: #{RSpecQ::DEFAULT_MAX_REQUEUES}).") do |v|
+       "(default: #{DEFAULT_MAX_REQUEUES}).") do |v|
     opts[:max_requeues] = v
   end
 
@@ -89,7 +90,7 @@ opts[:timings] ||= env_set?("RSPECQ_UPDATE_TIMINGS")
 opts[:file_split_threshold] ||= Integer(ENV["RSPECQ_FILE_SPLIT_THRESHOLD"] || 9999999)
 opts[:report] ||= env_set?("RSPECQ_REPORT")
 opts[:report_timeout] ||= Integer(ENV["RSPECQ_REPORT_TIMEOUT"] || DEFAULT_REPORT_TIMEOUT)
-opts[:max_requeues] ||= Integer(ENV["RSPECQ_MAX_REQUEUES"] || RSpecQ::DEFAULT_MAX_REQUEUES)
+opts[:max_requeues] ||= Integer(ENV["RSPECQ_MAX_REQUEUES"] || DEFAULT_MAX_REQUEUES)
 
 raise OptionParser::MissingArgument.new(:build) if opts[:build].nil?
 raise OptionParser::MissingArgument.new(:worker) if !opts[:report] && opts[:worker].nil?

--- a/bin/rspecq
+++ b/bin/rspecq
@@ -4,6 +4,7 @@ require "rspecq"
 
 DEFAULT_REDIS_HOST = "127.0.0.1"
 DEFAULT_REPORT_TIMEOUT = 3600 # 1 hour
+DEFAULT_MAX_REQUEUES = 3
 
 def env_set?(var)
   ["1", "true"].include?(ENV[var])
@@ -65,6 +66,11 @@ OptionParser.new do |o|
     opts[:report_timeout] = v
   end
 
+  o.on("--max-requeues N", Integer, "Sets the number of max requeues to N " \
+       "times (default: #{DEFAULT_MAX_REQUEUES}).") do |v|
+    opts[:max_requeues] = v
+  end
+
   o.on_tail("-h", "--help", "Show this message.") do
     puts o
     exit
@@ -83,6 +89,7 @@ opts[:timings] ||= env_set?("RSPECQ_UPDATE_TIMINGS")
 opts[:file_split_threshold] ||= Integer(ENV["RSPECQ_FILE_SPLIT_THRESHOLD"] || 9999999)
 opts[:report] ||= env_set?("RSPECQ_REPORT")
 opts[:report_timeout] ||= Integer(ENV["RSPECQ_REPORT_TIMEOUT"] || DEFAULT_REPORT_TIMEOUT)
+opts[:max_requeues] ||= Integer(ENV["MAX_REQUEUES"] || DEFAULT_MAX_REQUEUES)
 
 raise OptionParser::MissingArgument.new(:build) if opts[:build].nil?
 raise OptionParser::MissingArgument.new(:worker) if !opts[:report] && opts[:worker].nil?
@@ -101,6 +108,7 @@ else
     worker_id: opts[:worker],
     redis_host: opts[:redis_host],
     files_or_dirs_to_run: ARGV[0] || "spec",
+    max_requeues: opts[:max_requeues]
   )
 
   worker.populate_timings = opts[:timings]

--- a/lib/rspecq.rb
+++ b/lib/rspecq.rb
@@ -1,10 +1,6 @@
 require "rspec/core"
 
 module RSpecQ
-  # Failed examples will be retried by (usually) another worker up to
-  # MAX_REQUEUES times, as a mitigation against flaky tests.
-  MAX_REQUEUES = 3
-
   # If a worker haven't executed an example for more than WORKER_LIVENESS_SEC
   # seconds, it is considered dead and its reserved work will be put back
   # to the queue to be picked up by another worker.

--- a/lib/rspecq.rb
+++ b/lib/rspecq.rb
@@ -5,9 +5,6 @@ module RSpecQ
   # seconds, it is considered dead and its reserved work will be put back
   # to the queue to be picked up by another worker.
   WORKER_LIVENESS_SEC = 60.0
-
-  # If no value is given for max requeues, this value will be used.
-  DEFAULT_MAX_REQUEUES = 3
 end
 
 require_relative "rspecq/formatters/example_count_recorder"

--- a/lib/rspecq.rb
+++ b/lib/rspecq.rb
@@ -5,6 +5,9 @@ module RSpecQ
   # seconds, it is considered dead and its reserved work will be put back
   # to the queue to be picked up by another worker.
   WORKER_LIVENESS_SEC = 60.0
+
+  # If no value is given for max requeues, this value will be used.
+  DEFAULT_MAX_REQUEUES = 3
 end
 
 require_relative "rspecq/formatters/example_count_recorder"

--- a/lib/rspecq/formatters/failure_recorder.rb
+++ b/lib/rspecq/formatters/failure_recorder.rb
@@ -1,11 +1,12 @@
 module RSpecQ
   module Formatters
     class FailureRecorder
-      def initialize(queue, job)
+      def initialize(queue, job, max_requeues)
         @queue = queue
         @job = job
         @colorizer = RSpec::Core::Formatters::ConsoleCodes
         @non_example_error_recorded = false
+        @max_requeues = max_requeues
       end
 
       # Here we're notified about errors occuring outside of examples.
@@ -24,7 +25,7 @@ module RSpecQ
       def example_failed(notification)
         example = notification.example
 
-        if @queue.requeue_job(example.id, MAX_REQUEUES)
+        if @queue.requeue_job(example.id, @max_requeues)
           # HACK: try to avoid picking the job we just requeued; we want it
           # to be picked up by a different worker
           sleep 0.5

--- a/lib/rspecq/worker.rb
+++ b/lib/rspecq/worker.rb
@@ -15,9 +15,15 @@ module RSpecQ
     # will be split and scheduled on a per-example basis.
     attr_accessor :file_split_threshold
 
-    attr_reader :queue, :max_requeues
+    # Retry failed examples up to N times (with N being the supplied value)
+    # before considering them legit failures
+    # 
+    # Defaults to the value set in DEFAULT_MAX_REQUEUES
+    attr_accessor :max_requeues
 
-    def initialize(build_id:, worker_id:, redis_host:, files_or_dirs_to_run:, max_requeues:)
+    attr_reader :queue
+
+    def initialize(build_id:, worker_id:, redis_host:, files_or_dirs_to_run:)
       @build_id = build_id
       @worker_id = worker_id
       @queue = Queue.new(build_id, worker_id, redis_host)
@@ -25,7 +31,7 @@ module RSpecQ
       @populate_timings = false
       @file_split_threshold = 999999
       @heartbeat_updated_at = nil
-      @max_requeues = max_requeues
+      @max_requeues = DEFAULT_MAX_REQUEUES
 
       RSpec::Core::Formatters.register(Formatters::JobTimingRecorder, :dump_summary)
       RSpec::Core::Formatters.register(Formatters::ExampleCountRecorder, :dump_summary)

--- a/lib/rspecq/worker.rb
+++ b/lib/rspecq/worker.rb
@@ -18,7 +18,7 @@ module RSpecQ
     # Retry failed examples up to N times (with N being the supplied value)
     # before considering them legit failures
     # 
-    # Defaults to the value set in DEFAULT_MAX_REQUEUES
+    # Defaults to 3
     attr_accessor :max_requeues
 
     attr_reader :queue
@@ -31,7 +31,7 @@ module RSpecQ
       @populate_timings = false
       @file_split_threshold = 999999
       @heartbeat_updated_at = nil
-      @max_requeues = DEFAULT_MAX_REQUEUES
+      @max_requeues = 3
 
       RSpec::Core::Formatters.register(Formatters::JobTimingRecorder, :dump_summary)
       RSpec::Core::Formatters.register(Formatters::ExampleCountRecorder, :dump_summary)

--- a/test/test_e2e.rb
+++ b/test/test_e2e.rb
@@ -12,9 +12,9 @@ class TestEndToEnd < RSpecQTest
       "./spec/bar_spec.rb[1:2]",
     ], queue
 
-   assert_equal 3 + TestHelpers::MAX_REQUEUES, queue.example_count
+   assert_equal 3 + RSpecQ::DEFAULT_MAX_REQUEUES, queue.example_count
 
-   assert_equal({ "./spec/bar_spec.rb[1:2]" => "3" }, queue.requeued_jobs)
+   assert_equal({ "./spec/bar_spec.rb[1:2]" => RSpecQ::DEFAULT_MAX_REQUEUES.to_s }, queue.requeued_jobs)
   end
 
   def test_passing_suite
@@ -38,10 +38,13 @@ class TestEndToEnd < RSpecQTest
     assert_equal({ "./spec/foo_spec.rb[1:1]" => "2" }, queue.requeued_jobs)
   end
 
-  def test_suite_with_failures_without_retries
-    queue = exec_build("failing_suite", "--max-requeues=0")
+  def test_flakey_suite_without_retries
+    queue = exec_build("flakey_suite", "--max-requeues=0")
 
     refute(queue.build_successful?)
+    assert_processed_jobs [
+      "./spec/foo_spec.rb",
+    ], queue
 
     assert_empty(queue.requeued_jobs)
   end

--- a/test/test_e2e.rb
+++ b/test/test_e2e.rb
@@ -12,7 +12,7 @@ class TestEndToEnd < RSpecQTest
       "./spec/bar_spec.rb[1:2]",
     ], queue
 
-   assert_equal 3+RSpecQ::MAX_REQUEUES, queue.example_count
+   assert_equal 3 + TestHelpers::MAX_REQUEUES, queue.example_count
 
    assert_equal({ "./spec/bar_spec.rb[1:2]" => "3" }, queue.requeued_jobs)
   end
@@ -36,6 +36,14 @@ class TestEndToEnd < RSpecQTest
     ], queue
 
     assert_equal({ "./spec/foo_spec.rb[1:1]" => "2" }, queue.requeued_jobs)
+  end
+
+  def test_suite_with_failures_without_retries
+    queue = exec_build("failing_suite", "--max-requeues=0")
+
+    refute(queue.build_successful?)
+
+    assert_empty(queue.requeued_jobs)
   end
 
   def test_scheduling_by_file_and_custom_spec_path

--- a/test/test_e2e.rb
+++ b/test/test_e2e.rb
@@ -12,9 +12,9 @@ class TestEndToEnd < RSpecQTest
       "./spec/bar_spec.rb[1:2]",
     ], queue
 
-   assert_equal 3 + RSpecQ::DEFAULT_MAX_REQUEUES, queue.example_count
+   assert_equal 3 + 3, queue.example_count
 
-   assert_equal({ "./spec/bar_spec.rb[1:2]" => RSpecQ::DEFAULT_MAX_REQUEUES.to_s }, queue.requeued_jobs)
+   assert_equal({ "./spec/bar_spec.rb[1:2]" => "3" }, queue.requeued_jobs)
   end
 
   def test_passing_suite

--- a/test/test_helpers.rb
+++ b/test/test_helpers.rb
@@ -5,6 +5,7 @@ require "rspecq"
 module TestHelpers
   REDIS_HOST = "127.0.0.1".freeze
   EXEC_CMD = "bundle exec rspecq"
+  MAX_REQUEUES = 3
 
   def rand_id
     SecureRandom.hex(4)
@@ -16,6 +17,7 @@ module TestHelpers
       worker_id: rand_id,
       redis_host: REDIS_HOST,
       files_or_dirs_to_run: suite_path(path),
+      max_requeues: MAX_REQUEUES
     )
   end
 

--- a/test/test_helpers.rb
+++ b/test/test_helpers.rb
@@ -5,7 +5,6 @@ require "rspecq"
 module TestHelpers
   REDIS_HOST = "127.0.0.1".freeze
   EXEC_CMD = "bundle exec rspecq"
-  MAX_REQUEUES = 3
 
   def rand_id
     SecureRandom.hex(4)
@@ -17,7 +16,6 @@ module TestHelpers
       worker_id: rand_id,
       redis_host: REDIS_HOST,
       files_or_dirs_to_run: suite_path(path),
-      max_requeues: MAX_REQUEUES
     )
   end
 


### PR DESCRIPTION
Fixes #9 

Adds a CLI option to set max-requeues. It will default to 3 if the option is not given.