### PR TITLE
Implement Sentry integration

### DIFF
--- a/bin/rspecq
+++ b/bin/rspecq
@@ -24,7 +24,7 @@ OptionParser.new do |o|
   BANNER
 
   o.separator ""
-	o.separator "OPTIONS:"
+  o.separator "OPTIONS:"
 
   o.on("-b", "--build ID", "A unique identifier for the build. Should be " \
        "common among workers participating in the same build.") do |v|

--- a/lib/rspecq.rb
+++ b/lib/rspecq.rb
@@ -1,4 +1,5 @@
 require "rspec/core"
+require "sentry-raven"
 
 module RSpecQ
   # If a worker haven't executed an example for more than WORKER_LIVENESS_SEC

--- a/rspecq.gemspec
+++ b/rspecq.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |s|
   end
 
   s.add_dependency "redis"
+  s.add_dependency "sentry-raven"
 
   s.add_development_dependency "rake"
   s.add_development_dependency "pry-byebug"


### PR DESCRIPTION
This patch adds support for Workers to emit various RSpecQ internal events to
a Sentry[1] instance.

Reporting to Sentry is opt-in and is enabled by setting the SENTRY_DSN
environment variable (see
https://github.com/getsentry/raven-ruby#raven-only-runs-when-sentry_dsn-is-set).
If SENTRY_DSN is not set this is a noop.

Events emitted:

- [error] the spec file split command failed; slow spec files files will
  be scheduled as a whole so build times will be negatively impacted
- [warning] no previous timings were found in Redis; scheduling will be random
  so build times will be negatively impacted
- [info] slow files were detected and will be split, including the
  actual filenames

The above are still printed to the standard output of the worker.

Closes #8

[1] https://sentry.io