### PR TITLE
implement URI options

### DIFF
--- a/bin/rspecq
+++ b/bin/rspecq
@@ -41,6 +41,12 @@ OptionParser.new do |o|
     opts[:redis_host] = v
   end
 
+  o.on("--redis-url",
+        "Redis URL to connect to" \
+        "") do |v|
+    opts[:redis_url] = v
+  end
+
   o.on("--update-timings", "Update the global job timings key with the "     \
        "timings of this build. Note: This key is used as the basis for job " \
        "scheduling.") do |v|
@@ -95,11 +101,14 @@ opts[:max_requeues] ||= Integer(ENV["RSPECQ_MAX_REQUEUES"] || DEFAULT_MAX_REQUEU
 raise OptionParser::MissingArgument.new(:build) if opts[:build].nil?
 raise OptionParser::MissingArgument.new(:worker) if !opts[:report] && opts[:worker].nil?
 
+redis_opts = {host: opts[:redis_host]}
+redis_opts[:url] = opts[:redis_url] if opts[:redis_url]
+
 if opts[:report]
   reporter = RSpecQ::Reporter.new(
     build_id: opts[:build],
     timeout: opts[:report_timeout],
-    redis_host: opts[:redis_host],
+    redis_opts: redis_opts
   )
 
   reporter.report
@@ -107,7 +116,7 @@ else
   worker = RSpecQ::Worker.new(
     build_id: opts[:build],
     worker_id: opts[:worker],
-    redis_host: opts[:redis_host]
+    redis_opts: redis_opts
   )
 
   worker.files_or_dirs_to_run = ARGV[0] if ARGV[0]

--- a/lib/rspecq/queue.rb
+++ b/lib/rspecq/queue.rb
@@ -59,10 +59,10 @@ module RSpecQ
 
     attr_reader :redis
 
-    def initialize(build_id, worker_id, redis_host)
+    def initialize(build_id, worker_id, redis_opts)
       @build_id = build_id
       @worker_id = worker_id
-      @redis = Redis.new(host: redis_host, id: worker_id)
+      @redis = Redis.new(redis_opts.merge(id: worker_id))
     end
 
     # NOTE: jobs will be processed from head to tail (lpop)

--- a/lib/rspecq/reporter.rb
+++ b/lib/rspecq/reporter.rb
@@ -1,9 +1,9 @@
 module RSpecQ
   class Reporter
-    def initialize(build_id:, timeout:, redis_host:)
+    def initialize(build_id:, timeout:, redis_opts:)
       @build_id = build_id
       @timeout = timeout
-      @queue = Queue.new(build_id, "reporter", redis_host)
+      @queue = Queue.new(build_id, "reporter", redis_opts)
 
       # We want feedback to be immediattely printed to CI users, so
       # we disable buffering.

--- a/lib/rspecq/worker.rb
+++ b/lib/rspecq/worker.rb
@@ -30,10 +30,10 @@ module RSpecQ
 
     attr_reader :queue
 
-    def initialize(build_id:, worker_id:, redis_host:)
+    def initialize(build_id:, worker_id:, redis_opts:)
       @build_id = build_id
       @worker_id = worker_id
-      @queue = Queue.new(build_id, worker_id, redis_host)
+      @queue = Queue.new(build_id, worker_id, redis_opts)
       @files_or_dirs_to_run = "spec"
       @populate_timings = false
       @file_split_threshold = 999999

--- a/test/test_helpers.rb
+++ b/test/test_helpers.rb
@@ -3,7 +3,7 @@ require "securerandom"
 require "rspecq"
 
 module TestHelpers
-  REDIS_HOST = "127.0.0.1".freeze
+  REDIS_HOST = {host: "127.0.0.1".freeze}.tap{|e| e.merge(url: ENV['REDIS_URL']) if ENV['REDIS_URL']}
   EXEC_CMD = "bundle exec rspecq"
 
   def rand_id
@@ -14,7 +14,7 @@ module TestHelpers
     w = RSpecQ::Worker.new(
       build_id: rand_id,
       worker_id: rand_id,
-      redis_host: REDIS_HOST
+      redis_opts: REDIS_HOST
     )
     w.files_or_dirs_to_run = suite_path(path)
     w
@@ -90,6 +90,7 @@ class RSpecQTest < Minitest::Test
   include TestHelpers
 
   def setup
-    Redis.new(host: REDIS_HOST).flushdb
+    puts "flush redis: #{REDIS_HOST}"if ENV["RSPECQ_DEBUG"]
+    Redis.new(REDIS_HOST).flushdb
   end
 end


### PR DESCRIPTION
This change is for specifying REDIS connection options by URI.

I changed this option because I needed it. (for use redis on docker containers)

Closes #37 