### PR TITLE
Add visibility to flaky jobs

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ and [ci-queue](https://github.com/Shopify/ci-queue).
 
 ## Features
 
-- Run an RSpec suite among many workers 
+- Run an RSpec suite among many workers
   (potentially located in different hosts) in a distributed fashion,
   facilitating faster CI builds.
 - Consolidated, real-time reporting of a build's progress.
@@ -21,11 +21,11 @@ and [ci-queue](https://github.com/Shopify/ci-queue).
   automatically scheduling slow spec files as individual examples. See
   [*Spec file splitting*](#spec-file-splitting).
 - Automatic retry of test failures before being considered legit, in order to
-  rule out flakiness. See [*Requeues*](#requeues).
+  rule out flakiness. Additionally, flaky tests are detected and provided to
+  the user. See [*Requeues*](#requeues).
 - Handles intermittent worker failures (e.g. network hiccups, faulty hardware etc.)
   by detecting non-responsive workers and requeing their jobs. See [*Worker failures*](#worker-failures)
-- [Sentry](https://sentry.io) integration for monitoring important
-  RSpecQ-level events.
+- [Sentry](https://sentry.io) integration for monitoring build-level events.
 - [PLANNED] StatsD integration for various build-level metrics and insights.
   See [#2](https://github.com/skroutz/rspecq/issues/2).
 
@@ -124,9 +124,12 @@ dynamically (see #3).
 
 As a mitigation technique against flaky tests, if an example fails it will be
 put back to the queue to be picked up by another worker. This will be repeated
-up to a certain number of times (set with the `--max-requeues` option), after 
-which the example will be considered a legit failure and printed as such in the 
+up to a certain number of times (set with the `--max-requeues` option), after
+which the example will be considered a legit failure and printed as such in the
 final report.
+
+Flaky tests are also detected and printed as such in the final report. They are
+also emitted to Sentry (see [Sentry integration](#sentry-integration)).
 
 ### Worker failures
 

--- a/lib/rspecq/reporter.rb
+++ b/lib/rspecq/reporter.rb
@@ -45,8 +45,9 @@ module RSpecQ
       raise "Build not finished after #{@timeout} seconds" if !finished
 
       @queue.record_build_time(tests_duration)
+
       puts summary(@queue.example_failures, @queue.non_example_errors,
-                   humanize_duration(tests_duration))
+                   @queue.flaky_jobs, humanize_duration(tests_duration))
 
       exit 1 if !@queue.build_successful?
     end
@@ -60,7 +61,7 @@ module RSpecQ
     end
 
     # We try to keep this output consistent with RSpec's original output
-    def summary(failures, errors, duration)
+    def summary(failures, errors, flaky_jobs, duration)
       failed_examples_section = "\nFailed examples:\n\n"
 
       failures.each do |_job, msg|
@@ -81,6 +82,14 @@ module RSpecQ
                  "#{errors.count} errors"
       summary << "\n\n"
       summary << "Spec execution time: #{duration}"
+
+      if !flaky_jobs.empty?
+        summary << "\n\n"
+        summary << "Flaky jobs detected (count=#{flaky_jobs.count}):\n"
+        flaky_jobs.each { |j| summary << "  #{j}\n" }
+      end
+
+      summary
     end
 
     def failure_formatted(rspec_output)

--- a/test/sample_suites/flaky_job_detection/spec/flaky_spec.rb
+++ b/test/sample_suites/flaky_job_detection/spec/flaky_spec.rb
@@ -1,0 +1,17 @@
+RSpec.describe do
+  it "is flaky and passes the 3rd time" do
+    $tries_a ||= 0
+    $tries_a += 1
+
+    expect($tries_a).to eq 3
+  end
+
+  it { expect(true).to be true }
+
+  it "is flaky and passes the 2nd time" do
+    $tries_b ||= 0
+    $tries_b += 1
+
+    expect($tries_b).to eq 2
+  end
+end

--- a/test/sample_suites/flaky_job_detection/spec/legit_failure_spec.rb
+++ b/test/sample_suites/flaky_job_detection/spec/legit_failure_spec.rb
@@ -1,0 +1,6 @@
+RSpec.describe do
+  it { expect(1).to eq 1 }
+  it { expect(2).to eq 2 }
+
+  it { expect(false).to be true }
+end

--- a/test/sample_suites/flaky_job_detection/spec/passing_spec.rb
+++ b/test/sample_suites/flaky_job_detection/spec/passing_spec.rb
@@ -1,0 +1,5 @@
+RSpec.describe do
+  it { expect(1).to eq 1 }
+
+  it { expect(true).to be true }
+end

--- a/test/test_helpers.rb
+++ b/test/test_helpers.rb
@@ -4,7 +4,7 @@ require "rspecq"
 
 module TestHelpers
   REDIS_HOST = "127.0.0.1".freeze
-  EXEC_CMD = "bundle exec rspecq"
+  EXEC_CMD = "bundle exec rspecq".freeze
 
   def rand_id
     SecureRandom.hex(4)
@@ -56,10 +56,15 @@ module TestHelpers
     assert_equal exp.sort, queue.processed_jobs.sort
   end
 
+  def assert_failures(exp, queue)
+    assert_equal exp.sort, queue.example_failures.keys.sort
+  end
+
   def suite_path(path)
     File.join("test", "sample_suites", path)
   end
 
+  # Returns the worker pid
   def start_worker(build_id:, worker_id: rand_id, suite:)
     Process.spawn(
       "#{EXEC_CMD} -w #{worker_id} -b #{build_id}",

--- a/test/test_queue.rb
+++ b/test/test_queue.rb
@@ -1,0 +1,27 @@
+require "test_helpers"
+
+class TestQueue < RSpecQTest
+  def test_flaky_jobs
+    build_id = rand_id
+
+    Process.wait(start_worker(build_id: build_id, suite: "flaky_job_detection"))
+
+    queue = RSpecQ::Queue.new(build_id, "foo", REDIS_HOST)
+
+    assert_queue_well_formed(queue)
+    refute queue.build_successful?
+
+    assert_equal ["./spec/flaky_spec.rb[1:1]", "./spec/flaky_spec.rb[1:3]"],
+      queue.flaky_jobs.sort
+
+    assert_processed_jobs(
+      ["./spec/passing_spec.rb",
+       "./spec/flaky_spec.rb",
+       "./spec/flaky_spec.rb[1:1]",
+       "./spec/flaky_spec.rb[1:3]",
+       "./spec/legit_failure_spec.rb",
+       "./spec/legit_failure_spec.rb[1:3]"], queue)
+
+    assert_failures(["./spec/legit_failure_spec.rb[1:3]"], queue)
+  end
+end


### PR DESCRIPTION
These patches provide visibility to test suite flakiness by:

- printing the flaky jobs in the build summary (via reporter)
- emitting the flaky jobs to Sentry

A preview of the build summary output:

```
Failed examples:

  bin/rspec ./test/sample_suites/flaky_job_detection/spec/legit_failure_spec.rb:5 # is expected to equal true

Total results:
  13 examples (6 jobs), 1 failures, 0 errors

Spec execution time: 00:00:00

Flaky jobs detected (count=2):
  ./test/sample_suites/flaky_job_detection/spec/flaky_spec.rb[1:3]
  ./test/sample_suites/flaky_job_detection/spec/flaky_spec.rb[1:1]
```

And a preview from the Sentry event:

![flaky_sentry](https://user-images.githubusercontent.com/827224/91578545-fe399c80-e952-11ea-9612-d66943322c08.jpg)

Closes #21 