### PR TITLE
reporter: Improve flaky job Sentry reporting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ Breaking changes are prefixed with a "[BREAKING]" label.
 
 ## master (unreleased)
 
+### Changed
+
+- Sentry Integration: Changed the way events for flaky jobs are emitted to a
+  per-flaky-job fashion. This ultimately improves grouping and filtering of the
+  flaky events in Sentry [[#33](https://github.com/skroutz/rspecq/pull/33)]
 
 
 ## 0.2.0 (2020-08-31)


### PR DESCRIPTION
This patch has the following changes in order to accommodate better
visibility in the flaky jobs. First and foremost, the reporting is now
on a **per flaky job basis** (instead of a generic "Flaky jobs detected")
exception.

In this way, every event for a specific test is grouped with its
predecessors thus enabling chronological sorting, and volume of events
per test case.

A tag "flaky" was also added in the event so that the flaky job exceptions
can be filtered out better.

Fixes: #31 