### PR TITLE
Catch stderr and stdout separately when splitting files

### DIFF
--- a/test/sample_suites/deprecation_warning/README
+++ b/test/sample_suites/deprecation_warning/README
@@ -1,0 +1,2 @@
+A suite that simulates a deprecation warning printed to standard error from
+e.g. some gem or some application initializer.

--- a/test/sample_suites/deprecation_warning/spec/foo_spec.rb
+++ b/test/sample_suites/deprecation_warning/spec/foo_spec.rb
@@ -1,0 +1,13 @@
+$stderr.puts "I'm a warning!"
+
+describe "A slow spec file to be splitted" do
+  it do
+    sleep 0.1
+    expect(true).to be true
+  end
+
+  it do
+    sleep 0.2
+    expect(true).to be true
+  end
+end

--- a/test/test_scheduling.rb
+++ b/test/test_scheduling.rb
@@ -75,4 +75,25 @@ class TestScheduling < RSpecQTest
       "./test/sample_suites/scheduling_untimed/spec/foo/baz_spec.rb",
     ], worker.queue.unprocessed_jobs
   end
+
+  def test_splitting_with_deprecation_warning
+    worker = new_worker("deprecation_warning")
+    worker.populate_timings = true
+    silent { worker.work }
+
+    assert_queue_well_formed(worker.queue)
+    assert worker.queue.build_successful?
+    refute_empty worker.queue.timings
+
+    worker = new_worker("deprecation_warning")
+    worker.file_split_threshold = 0.2
+    silent { worker.work }
+
+    assert_queue_well_formed(worker.queue)
+    assert worker.queue.build_successful?
+    assert_processed_jobs([
+      "./test/sample_suites/deprecation_warning/spec/foo_spec.rb[1:1]",
+      "./test/sample_suites/deprecation_warning/spec/foo_spec.rb[1:2]",
+    ], worker.queue)
+  end
 end


### PR DESCRIPTION
Fixes #34

Co-authored-by: Agis Anastasopoulos <a@xz0.org>