### PR TITLE
Split spec files to examples programmatically

### DIFF
--- a/lib/rspecq/worker.rb
+++ b/lib/rspecq/worker.rb
@@ -204,6 +204,7 @@ module RSpecQ
     private
 
     def reset_rspec_state!
+      RSpec.reset
       RSpec.clear_examples
 
       # see https://github.com/rspec/rspec-core/pull/2723

--- a/lib/rspecq/worker.rb
+++ b/lib/rspecq/worker.rb
@@ -172,28 +172,6 @@ module RSpecQ
       puts "Published queue (size=#{queue.publish(jobs, fail_fast)})"
     end
 
-    private
-
-    def reset_rspec_state!
-      RSpec.clear_examples
-
-      # see https://github.com/rspec/rspec-core/pull/2723
-      if Gem::Version.new(RSpec::Core::Version::STRING) <= Gem::Version.new("3.9.1")
-        RSpec.world.instance_variable_set(
-          :@example_group_counts_by_spec_file, Hash.new(0)
-        )
-      end
-
-      # RSpec.clear_examples does not reset those, which causes issues when
-      # a non-example error occurs (subsequent jobs are not executed)
-      # TODO: upstream
-      RSpec.world.non_example_failure = false
-
-      # we don't want an error that occured outside of the examples (which
-      # would set this to `true`) to stop the worker
-      RSpec.world.wants_to_quit = false
-    end
-
     # NOTE: RSpec has to load the files before we can split them as individual
     # examples. In case a file to be splitted fails to be loaded
     # (e.g. contains a syntax error), we return the files unchanged, thereby
@@ -225,6 +203,29 @@ module RSpecQ
 
       JSON.parse(out)["examples"].map { |e| e["id"] }
     end
+
+    private
+
+    def reset_rspec_state!
+      RSpec.clear_examples
+
+      # see https://github.com/rspec/rspec-core/pull/2723
+      if Gem::Version.new(RSpec::Core::Version::STRING) <= Gem::Version.new("3.9.1")
+        RSpec.world.instance_variable_set(
+          :@example_group_counts_by_spec_file, Hash.new(0)
+        )
+      end
+
+      # RSpec.clear_examples does not reset those, which causes issues when
+      # a non-example error occurs (subsequent jobs are not executed)
+      # TODO: upstream
+      RSpec.world.non_example_failure = false
+
+      # we don't want an error that occured outside of the examples (which
+      # would set this to `true`) to stop the worker
+      RSpec.world.wants_to_quit = false
+    end
+
 
     def relative_path(job)
       @cwd ||= Pathname.new(Dir.pwd)

--- a/test/sample_suites/files_to_examples/spec/bar_spec.rb
+++ b/test/sample_suites/files_to_examples/spec/bar_spec.rb
@@ -1,0 +1,3 @@
+RSpec.describe "baz" do
+  it { expect(1).to eq 2 }
+end

--- a/test/sample_suites/files_to_examples/spec/foo_spec.rb
+++ b/test/sample_suites/files_to_examples/spec/foo_spec.rb
@@ -1,0 +1,15 @@
+RSpec.describe "foo" do
+  it "works" do
+    expect(true).to be true
+  end
+
+  context "hmm" do
+    it "or not" do
+      expect(true).to be true
+    end
+
+    it "well, maybe" do
+      expect(true).to be true
+    end
+  end
+end

--- a/test/sample_suites/files_to_examples_fallback/spec/bar_spec.rb
+++ b/test/sample_suites/files_to_examples_fallback/spec/bar_spec.rb
@@ -1,0 +1,3 @@
+RSpec.describe "baz" do
+  it { expect(1).to eq 2 }
+end

--- a/test/sample_suites/files_to_examples_fallback/spec/foo_spec.rb
+++ b/test/sample_suites/files_to_examples_fallback/spec/foo_spec.rb
@@ -1,0 +1,15 @@
+IdontExistz1337.describe "foo" do
+  it "works" do
+    expect(true).to be true
+  end
+
+  context "hmm" do
+    it "or not" do
+      expect(true).to be true
+    end
+
+    it "well, maybe" do
+      expect(true).to be true
+    end
+  end
+end

--- a/test/test_helpers.rb
+++ b/test/test_helpers.rb
@@ -58,11 +58,14 @@ module TestHelpers
     end
 
     begin
-      orig = $stdout.clone
+      orig_out = $stdout.clone
+      orig_err = $stderr.clone
       $stdout.reopen(File::NULL, "w")
+      $stderr.reopen(File::NULL, "w")
       yield
     ensure
-      $stdout.reopen(orig)
+      $stdout.reopen(orig_out)
+      $stderr.reopen(orig_err)
     end
   end
 end

--- a/test/test_worker.rb
+++ b/test/test_worker.rb
@@ -1,0 +1,41 @@
+require "test_helpers"
+
+class TestWorker < RSpecQTest
+  def test_files_to_example_ids
+    worker = new_worker("files_to_examples")
+
+    expected = [
+      "./test/sample_suites/files_to_examples/spec/foo_spec.rb[1:1]",
+      "./test/sample_suites/files_to_examples/spec/foo_spec.rb[1:2:1]",
+      "./test/sample_suites/files_to_examples/spec/foo_spec.rb[1:2:2]",
+      "./test/sample_suites/files_to_examples/spec/bar_spec.rb[1:1]",
+    ].sort
+
+    actual = worker.files_to_example_ids(
+      [
+        "./test/sample_suites/files_to_examples/spec/foo_spec.rb",
+        "./test/sample_suites/files_to_examples/spec/bar_spec.rb",
+      ]
+    ).sort
+
+    assert_equal expected, actual
+  end
+
+  def test_files_to_example_ids_failure_fallback
+    worker = new_worker("files_to_examples_fallback")
+
+    expected = [
+      "./test/sample_suites/files_to_examples_fallback/spec/foo_spec.rb",
+      "./test/sample_suites/files_to_examples_fallback/spec/bar_spec.rb"
+    ].sort
+
+    actual = worker.files_to_example_ids(
+      [
+        "./test/sample_suites/files_to_examples_fallback/spec/foo_spec.rb",
+        "./test/sample_suites/files_to_examples_fallback/spec/bar_spec.rb",
+      ]
+    ).sort
+
+    assert_equal expected, actual
+  end
+end


### PR DESCRIPTION
Instead of shelling out to rspec, we now split spec files into individual examples programmatically, using the RSpec Core API. This is faster and more robust, since we avoid common shell shenanigans.

Closes #6

