### PR TITLE
Add fast fail termination

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ Breaking changes are prefixed with a "[BREAKING]" label.
 
 ## master (unreleased)
 
+### Added
+
+- Builds can be configured to terminate after a specified number of failures,
+  using the `--fail-fast` option.
+
+
 ## 0.3.0 (2020-10-05)
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ OPTIONS:
                                      Exits with a non-zero status code if there were any failures.
         --report-timeout N           Fail if build is not finished after N seconds. Only applicable if --report is enabled (default: 3600).
         --max-requeues N             Retry failed examples up to N times before considering them legit failures (default: 3).
+        --fail-fast N                Abort build with a non-zero status code after N failed examples.
     -h, --help                       Show this message.
     -v, --version                    Print the version and exit.
 ```
@@ -132,6 +133,16 @@ final report.
 
 Flaky tests are also detected and printed as such in the final report. They are
 also emitted to Sentry (see [Sentry integration](#sentry-integration)).
+
+### Fail-fast
+
+In order to prevent large suites running for a long time with a lot of
+failures, a threshold can be set to control the number of failed examples that
+will render the build unsuccessful. This is in par with RSpec's
+[--fail-fast](https://relishapp.com/rspec/rspec-core/docs/command-line/fail-fast-option).
+
+This feature is disabled by default, and can be controlled via the
+`--fail-fast` command line option.
 
 ### Worker failures
 

--- a/bin/rspecq
+++ b/bin/rspecq
@@ -5,6 +5,7 @@ require "rspecq"
 DEFAULT_REDIS_HOST = "127.0.0.1"
 DEFAULT_REPORT_TIMEOUT = 3600 # 1 hour
 DEFAULT_MAX_REQUEUES = 3
+DEFAULT_FAIL_FAST = 0
 
 def env_set?(var)
   ["1", "true"].include?(ENV[var])
@@ -83,6 +84,11 @@ OptionParser.new do |o|
     opts[:max_requeues] = v
   end
 
+  o.on("--fail-fast N", Integer, "Abort build with a non-zero status code " \
+       "after N failed examples." ) do |v|
+    opts[:fail_fast] = v
+  end
+
   o.on_tail("-h", "--help", "Show this message.") do
     puts o
     exit
@@ -103,6 +109,7 @@ opts[:report] ||= env_set?("RSPECQ_REPORT")
 opts[:report_timeout] ||= Integer(ENV["RSPECQ_REPORT_TIMEOUT"] || DEFAULT_REPORT_TIMEOUT)
 opts[:max_requeues] ||= Integer(ENV["RSPECQ_MAX_REQUEUES"] || DEFAULT_MAX_REQUEUES)
 opts[:redis_url] ||= ENV["RSPECQ_REDIS_URL"]
+opts[:fail_fast] ||= Integer(ENV["RSPECQ_FAIL_FAST"] || DEFAULT_FAIL_FAST)
 
 raise OptionParser::MissingArgument.new(:build) if opts[:build].nil?
 raise OptionParser::MissingArgument.new(:worker) if !opts[:report] && opts[:worker].nil?
@@ -134,5 +141,6 @@ else
   worker.populate_timings = opts[:timings]
   worker.file_split_threshold = opts[:file_split_threshold]
   worker.max_requeues = opts[:max_requeues]
+  worker.fail_fast = opts[:fail_fast]
   worker.work
 end

--- a/lib/rspecq/reporter.rb
+++ b/lib/rspecq/reporter.rb
@@ -41,7 +41,7 @@ module RSpecQ
             puts failure_formatted(rspec_output)
           end
 
-          if !@queue.exhausted?
+          unless @queue.exhausted? || @queue.build_failed_fast?
             sleep 1
             next
           end
@@ -83,6 +83,13 @@ module RSpecQ
       end
 
       summary = ""
+      if @queue.build_failed_fast?
+        summary << "\n\n"
+        summary << "The limit of #{@queue.fail_fast} failures has been reached\n"
+        summary << "Aborting..."
+        summary << "\n"
+      end
+
       summary << failed_examples_section if !failures.empty?
 
       errors.each { |_job, msg| summary << msg }

--- a/test/sample_suites/failing_suite/spec/bar_spec.rb
+++ b/test/sample_suites/failing_suite/spec/bar_spec.rb
@@ -1,4 +1,0 @@
-RSpec.describe do
-  it { expect(false).to be false }
-  it { expect(1).to be 2 }
-end

--- a/test/sample_suites/failing_suite/spec/fail_1_spec.rb
+++ b/test/sample_suites/failing_suite/spec/fail_1_spec.rb
@@ -1,0 +1,4 @@
+RSpec.describe do
+  it { expect(false).to eq false }
+  it { expect(1).to eq 2 }
+end

--- a/test/sample_suites/failing_suite/spec/fail_2_spec.rb
+++ b/test/sample_suites/failing_suite/spec/fail_2_spec.rb
@@ -1,0 +1,4 @@
+RSpec.describe do
+  it { expect(false).to eq false }
+  it { expect(1).to eq 2 }
+end

--- a/test/sample_suites/failing_suite/spec/foo_spec.rb
+++ b/test/sample_suites/failing_suite/spec/foo_spec.rb
@@ -1,3 +1,0 @@
-RSpec.describe do
-  it { expect(true).to be true }
-end

--- a/test/sample_suites/failing_suite/spec/success_spec.rb
+++ b/test/sample_suites/failing_suite/spec/success_spec.rb
@@ -1,0 +1,3 @@
+RSpec.describe do
+  it { expect(true).to eq true }
+end

--- a/test/test_e2e.rb
+++ b/test/test_e2e.rb
@@ -5,7 +5,10 @@ class TestEndToEnd < RSpecQTest
     queue = exec_build("failing_suite")
 
     refute queue.build_successful?
+    assert queue.fail_fast.zero?
+    refute queue.build_failed_fast?
 
+    assert_empty queue.unprocessed_jobs
     assert_processed_jobs [
       "./spec/fail_1_spec.rb",
       "./spec/fail_1_spec.rb[1:2]",
@@ -108,5 +111,21 @@ class TestEndToEnd < RSpecQTest
       "./spec/slow_spec.rb[1:1]",
       "./spec/fast_spec.rb",
     ], queue)
+  end
+
+  def test_suite_with_failures_and_fail_fast
+    queue = exec_build("failing_suite", "--fail-fast 1")
+
+    assert_equal 1, queue.fail_fast
+    assert queue.build_failed_fast?
+    refute queue.build_successful?
+    assert_equal queue.fail_fast, queue.example_failures.length +
+                                  queue.non_example_errors.length
+
+    # 1 <= unprocessed_jobs <= 2
+    # Either Success, Fail (after N requeues), or Fail (after N requeues)
+    assert_includes [1, 2], queue.unprocessed_jobs.length
+
+    assert_includes [2, 3], queue.processed_jobs.length
   end
 end

--- a/test/test_e2e.rb
+++ b/test/test_e2e.rb
@@ -7,14 +7,19 @@ class TestEndToEnd < RSpecQTest
     refute queue.build_successful?
 
     assert_processed_jobs [
-      "./spec/foo_spec.rb",
-      "./spec/bar_spec.rb",
-      "./spec/bar_spec.rb[1:2]",
+      "./spec/fail_1_spec.rb",
+      "./spec/fail_1_spec.rb[1:2]",
+      "./spec/fail_2_spec.rb",
+      "./spec/fail_2_spec.rb[1:2]",
+      "./spec/success_spec.rb",
     ], queue
 
-   assert_equal 3 + 3, queue.example_count
+   assert_equal 3 + 3 + 5, queue.example_count
 
-   assert_equal({ "./spec/bar_spec.rb[1:2]" => "3" }, queue.requeued_jobs)
+   assert_equal({
+     "./spec/fail_1_spec.rb[1:2]" => "3",
+     "./spec/fail_2_spec.rb[1:2]" => "3",
+   }, queue.requeued_jobs)
   end
 
   def test_passing_suite

--- a/test/test_helpers/assertions.rb
+++ b/test/test_helpers/assertions.rb
@@ -6,7 +6,7 @@ module TestHelpers
         queue.send(:key_worker_heartbeats), 0, -1, withscores: true)
 
       assert queue.published?
-      assert queue.exhausted?
+      assert (queue.build_failed_fast? || queue.exhausted?)
       assert_operator heartbeats.size, :>=, 0
       assert heartbeats.all? { |hb| Time.at(hb.last) <= Time.now }
     end


### PR DESCRIPTION
This pull requests add support that can terminate the execution after an arbitrary number of failed tests. This goes in par with RSpec's [--fail-fast][1] option. The main implementation idea is the following:

1. Worker receives an optional `--fail-fast` parameter which is propagated into the queue.
2. Queue has a `build_failed_fast?` method which returns true if `fail_fast` is set and the sum of errors and failures is greater or equal to this number
3. Each worker, before dequeueing a new job, checks if the suite is failed. If so, it terminates its execution.

Example of fail fast report:

```
$ bundle exec bin/rspecq -b <build-id> --report --fail-fast 1
...
....
**Fail fast was enabled for this run**(threshold=1)
The test run has quited after 1 failed tests.

... Actual failures
```

Fixes: #19 

[1]: https://relishapp.com/rspec/rspec-core/docs/command-line/fail-fast-option