### PR TITLE
Add support for specifying redis host via a redis URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ OPTIONS:
     -b, --build ID                   A unique identifier for the build. Should be common among workers participating in the same build.
     -w, --worker ID                  An identifier for the worker. Workers participating in the same build should have distinct IDs.
     -r, --redis HOST                 Redis host to connect to (default: 127.0.0.1).
+        --redis-url REDIS_URL        Redis URL to connect to (ex: redis://127.0.0.1:6379/0).
         --update-timings             Update the global job timings key with the timings of this build. Note: This key is used as the basis for job scheduling.
         --file-split-threshold N     Split spec files slower than N seconds and schedule them as individual examples.
         --report                     Enable reporter mode: do not pull tests off the queue; instead print build progress and exit when it's finished.

--- a/README.md
+++ b/README.md
@@ -64,7 +64,8 @@ USAGE:
 OPTIONS:
     -b, --build ID                   A unique identifier for the build. Should be common among workers participating in the same build.
     -w, --worker ID                  An identifier for the worker. Workers participating in the same build should have distinct IDs.
-    -r, --redis HOST                 Redis host to connect to (default: 127.0.0.1).
+    -r, --redis HOST                 DEPRECATED: Use --redis-host or --redis-url instead. Redis host to connect to (default: 127.0.0.1).
+        --redis-host HOST            Redis host to connect to (default: 127.0.0.1).
         --redis-url REDIS_URL        Redis URL to connect to (ex: redis://127.0.0.1:6379/0).
         --update-timings             Update the global job timings key with the timings of this build. Note: This key is used as the basis for job scheduling.
         --file-split-threshold N     Split spec files slower than N seconds and schedule them as individual examples.

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ OPTIONS:
     -w, --worker ID                  An identifier for the worker. Workers participating in the same build should have distinct IDs.
     -r, --redis HOST                 DEPRECATED: Use --redis-host or --redis-url instead. Redis host to connect to (default: 127.0.0.1).
         --redis-host HOST            Redis host to connect to (default: 127.0.0.1).
-        --redis-url REDIS_URL        Redis URL to connect to (ex: redis://127.0.0.1:6379/0).
+        --redis-url URL             Redis URL to connect to (e.g.: redis://127.0.0.1:6379/0).
         --update-timings             Update the global job timings key with the timings of this build. Note: This key is used as the basis for job scheduling.
         --file-split-threshold N     Split spec files slower than N seconds and schedule them as individual examples.
         --report                     Enable reporter mode: do not pull tests off the queue; instead print build progress and exit when it's finished.

--- a/README.md
+++ b/README.md
@@ -64,9 +64,9 @@ USAGE:
 OPTIONS:
     -b, --build ID                   A unique identifier for the build. Should be common among workers participating in the same build.
     -w, --worker ID                  An identifier for the worker. Workers participating in the same build should have distinct IDs.
-    -r, --redis HOST                 DEPRECATED: Use --redis-host or --redis-url instead. Redis host to connect to (default: 127.0.0.1).
+    -r, --redis HOST                 --redis is deprecated. Use --redis-host or --redis-url instead. Redis host to connect to (default: 127.0.0.1).
         --redis-host HOST            Redis host to connect to (default: 127.0.0.1).
-        --redis-url URL             Redis URL to connect to (e.g.: redis://127.0.0.1:6379/0).
+        --redis-url URL              Redis URL to connect to (e.g.: redis://127.0.0.1:6379/0).
         --update-timings             Update the global job timings key with the timings of this build. Note: This key is used as the basis for job scheduling.
         --file-split-threshold N     Split spec files slower than N seconds and schedule them as individual examples.
         --report                     Enable reporter mode: do not pull tests off the queue; instead print build progress and exit when it's finished.

--- a/bin/rspecq
+++ b/bin/rspecq
@@ -3,7 +3,6 @@ require "optparse"
 require "rspecq"
 
 DEFAULT_REDIS_HOST = "127.0.0.1"
-DEFAULT_REDIS_URL = "redis://127.0.0.1:6379/0"
 DEFAULT_REPORT_TIMEOUT = 3600 # 1 hour
 DEFAULT_MAX_REQUEUES = 3
 
@@ -48,8 +47,8 @@ OptionParser.new do |o|
     opts[:redis_host] = v
   end
 
-  o.on("--redis-url REDIS_URL", "The URL of the Redis host to connect to " \
-       "(ex: #{DEFAULT_REDIS_URL}).") do |v|
+  o.on("--redis-url URL", "The URL of the Redis host to connect to " \
+       "(e.g.: redis://127.0.0.1:6379/0).") do |v|
     opts[:redis_url] = v
   end
 
@@ -107,8 +106,11 @@ opts[:max_requeues] ||= Integer(ENV["RSPECQ_MAX_REQUEUES"] || DEFAULT_MAX_REQUEU
 raise OptionParser::MissingArgument.new(:build) if opts[:build].nil?
 raise OptionParser::MissingArgument.new(:worker) if !opts[:report] && opts[:worker].nil?
 
-redis_opts = {host: opts[:redis_host]}
-redis_opts[:url] = opts[:redis_url] if opts[:redis_url]
+redis_opts = {
+  host: opts[:redis_host]
+}
+redis_url = ENV["RSPECQ_REDIS_URL"] || opts[:redis_url]
+redis_opts[:url] = redis_url if redis_url
 
 if opts[:report]
   reporter = RSpecQ::Reporter.new(

--- a/bin/rspecq
+++ b/bin/rspecq
@@ -3,6 +3,7 @@ require "optparse"
 require "rspecq"
 
 DEFAULT_REDIS_HOST = "127.0.0.1"
+DEFAULT_REDIS_URL = "redis://127.0.0.1:6379/0"
 DEFAULT_REPORT_TIMEOUT = 3600 # 1 hour
 DEFAULT_MAX_REQUEUES = 3
 
@@ -39,6 +40,11 @@ OptionParser.new do |o|
   o.on("-r", "--redis HOST", "Redis host to connect to " \
        "(default: #{DEFAULT_REDIS_HOST}).") do |v|
     opts[:redis_host] = v
+  end
+
+  o.on("--redis-url REDIS_URL", "The URL of the Redis host to connect to " \
+       "(ex: #{DEFAULT_REDIS_URL}).") do |v|
+    opts[:redis_url] = v
   end
 
   o.on("--update-timings", "Update the global job timings key with the "     \
@@ -95,11 +101,14 @@ opts[:max_requeues] ||= Integer(ENV["RSPECQ_MAX_REQUEUES"] || DEFAULT_MAX_REQUEU
 raise OptionParser::MissingArgument.new(:build) if opts[:build].nil?
 raise OptionParser::MissingArgument.new(:worker) if !opts[:report] && opts[:worker].nil?
 
+redis_opts = {host: opts[:redis_host]}
+redis_opts[:url] = opts[:redis_url] if opts[:redis_url]
+
 if opts[:report]
   reporter = RSpecQ::Reporter.new(
     build_id: opts[:build],
     timeout: opts[:report_timeout],
-    redis_host: opts[:redis_host],
+    redis_opts: redis_opts,
   )
 
   reporter.report
@@ -107,7 +116,7 @@ else
   worker = RSpecQ::Worker.new(
     build_id: opts[:build],
     worker_id: opts[:worker],
-    redis_host: opts[:redis_host]
+    redis_opts: redis_opts
   )
 
   worker.files_or_dirs_to_run = ARGV[0] if ARGV[0]

--- a/bin/rspecq
+++ b/bin/rspecq
@@ -39,6 +39,12 @@ OptionParser.new do |o|
 
   o.on("-r", "--redis HOST", "Redis host to connect to " \
        "(default: #{DEFAULT_REDIS_HOST}).") do |v|
+    puts "DEPRECATED: Use --redis-host or --redis-url instead"
+    opts[:redis_host] = v
+  end
+
+  o.on("--redis-host HOST", "Redis host to connect to " \
+       "(default: #{DEFAULT_REDIS_HOST}).") do |v|
     opts[:redis_host] = v
   end
 

--- a/bin/rspecq
+++ b/bin/rspecq
@@ -38,7 +38,7 @@ OptionParser.new do |o|
 
   o.on("-r", "--redis HOST", "Redis host to connect to " \
        "(default: #{DEFAULT_REDIS_HOST}).") do |v|
-    puts "DEPRECATED: Use --redis-host or --redis-url instead"
+    puts "--redis is deprecated. Use --redis-host or --redis-url instead"
     opts[:redis_host] = v
   end
 
@@ -102,15 +102,14 @@ opts[:file_split_threshold] ||= Integer(ENV["RSPECQ_FILE_SPLIT_THRESHOLD"] || 99
 opts[:report] ||= env_set?("RSPECQ_REPORT")
 opts[:report_timeout] ||= Integer(ENV["RSPECQ_REPORT_TIMEOUT"] || DEFAULT_REPORT_TIMEOUT)
 opts[:max_requeues] ||= Integer(ENV["RSPECQ_MAX_REQUEUES"] || DEFAULT_MAX_REQUEUES)
+opts[:redis_url] ||= ENV["RSPECQ_REDIS_URL"]
 
 raise OptionParser::MissingArgument.new(:build) if opts[:build].nil?
 raise OptionParser::MissingArgument.new(:worker) if !opts[:report] && opts[:worker].nil?
 
-redis_opts = {
-  host: opts[:redis_host]
-}
-redis_url = ENV["RSPECQ_REDIS_URL"] || opts[:redis_url]
-redis_opts[:url] = redis_url if redis_url
+redis_opts = {}
+redis_opts[:host] = opts[:redis_host] if opts[:redis_host]
+redis_opts[:url] = opts[:redis_url] if opts[:redis_url]
 
 if opts[:report]
   reporter = RSpecQ::Reporter.new(

--- a/lib/rspecq/queue.rb
+++ b/lib/rspecq/queue.rb
@@ -70,10 +70,10 @@ module RSpecQ
 
     attr_reader :redis
 
-    def initialize(build_id, worker_id, redis_host)
+    def initialize(build_id, worker_id, redis_opts)
       @build_id = build_id
       @worker_id = worker_id
-      @redis = Redis.new(host: redis_host, id: worker_id)
+      @redis = Redis.new(redis_opts.merge(id: worker_id))
     end
 
     # NOTE: jobs will be processed from head to tail (lpop)

--- a/lib/rspecq/reporter.rb
+++ b/lib/rspecq/reporter.rb
@@ -9,10 +9,10 @@ module RSpecQ
   #
   # Reporters are readers of the queue.
   class Reporter
-    def initialize(build_id:, timeout:, redis_host:)
+    def initialize(build_id:, timeout:, redis_opts:)
       @build_id = build_id
       @timeout = timeout
-      @queue = Queue.new(build_id, "reporter", redis_host)
+      @queue = Queue.new(build_id, "reporter", redis_opts)
 
       # We want feedback to be immediattely printed to CI users, so
       # we disable buffering.

--- a/lib/rspecq/worker.rb
+++ b/lib/rspecq/worker.rb
@@ -42,10 +42,10 @@ module RSpecQ
 
     attr_reader :queue
 
-    def initialize(build_id:, worker_id:, redis_host:)
+    def initialize(build_id:, worker_id:, redis_opts:)
       @build_id = build_id
       @worker_id = worker_id
-      @queue = Queue.new(build_id, worker_id, redis_host)
+      @queue = Queue.new(build_id, worker_id, redis_opts)
       @files_or_dirs_to_run = "spec"
       @populate_timings = false
       @file_split_threshold = 999999

--- a/test/test_concurrent_workers.rb
+++ b/test/test_concurrent_workers.rb
@@ -22,7 +22,7 @@ class TestConcurrentWorkers < RSpecQTest
 
     assert_operator elapsed, :<, 5
 
-    queue = RSpecQ::Queue.new(build_id, "foo", REDIS_HOST)
+    queue = RSpecQ::Queue.new(build_id, "foo", REDIS_OPTS)
 
     assert_queue_well_formed(queue)
     assert queue.build_successful?

--- a/test/test_helpers.rb
+++ b/test/test_helpers.rb
@@ -3,7 +3,7 @@ require "securerandom"
 require "rspecq"
 
 module TestHelpers
-  REDIS_HOST = "127.0.0.1".freeze
+  REDIS_OPTS = {host: "127.0.0.1"}.freeze
   EXEC_CMD = "bundle exec rspecq".freeze
 
   def rand_id
@@ -14,7 +14,7 @@ module TestHelpers
     w = RSpecQ::Worker.new(
       build_id: rand_id,
       worker_id: rand_id,
-      redis_host: REDIS_HOST
+      redis_opts: REDIS_OPTS
     )
     w.files_or_dirs_to_run = suite_path(path)
     w
@@ -31,7 +31,7 @@ module TestHelpers
 
     assert_equal 0, $?.exitstatus
 
-    queue = RSpecQ::Queue.new(build_id, worker_id, REDIS_HOST)
+    queue = RSpecQ::Queue.new(build_id, worker_id, REDIS_OPTS)
     assert_queue_well_formed(queue)
 
     return queue

--- a/test/test_helpers/rspecq_test.rb
+++ b/test/test_helpers/rspecq_test.rb
@@ -6,6 +6,6 @@ class RSpecQTest < Minitest::Test
   include TestHelpers::Assertions
 
   def setup
-    Redis.new(host: REDIS_HOST).flushdb
+    Redis.new(REDIS_OPTS).flushdb
   end
 end

--- a/test/test_queue.rb
+++ b/test/test_queue.rb
@@ -6,7 +6,7 @@ class TestQueue < RSpecQTest
 
     Process.wait(start_worker(build_id: build_id, suite: "flaky_job_detection"))
 
-    queue = RSpecQ::Queue.new(build_id, "foo", REDIS_HOST)
+    queue = RSpecQ::Queue.new(build_id, "foo", REDIS_OPTS)
 
     assert_queue_well_formed(queue)
     refute queue.build_successful?


### PR DESCRIPTION
Nearly identical of #25, which hasn't had any movement. 

+ Implements requested changes and resolves merge conflicts
+ Updates README
+ Deprecates `-r` and `--redis` CLI usage per [this comment](https://github.com/skroutz/rspecq/pull/25#issuecomment-683130330).

Closes #37.