### PR TITLE
WIP - Add support for outputting junit formatted xml

### DIFF
--- a/bin/rspecq
+++ b/bin/rspecq
@@ -89,9 +89,9 @@ OptionParser.new do |o|
     opts[:fail_fast] = v
   end
 
-  o.on("--include-suite-in-filename", "Add suite count to output file names so " \
-    "so that all suites are presented in output files.") do |v|
-    opts[:include_suite_in_filename] = v
+  o.on("--output-junit", "Output junit formatted xml " \
+    "for CI suites.") do |v|
+    opts[:output_junit] = v
   end
 
   o.on_tail("-h", "--help", "Show this message.") do
@@ -115,7 +115,7 @@ opts[:report_timeout] ||= Integer(ENV["RSPECQ_REPORT_TIMEOUT"] || DEFAULT_REPORT
 opts[:max_requeues] ||= Integer(ENV["RSPECQ_MAX_REQUEUES"] || DEFAULT_MAX_REQUEUES)
 opts[:redis_url] ||= ENV["RSPECQ_REDIS_URL"]
 opts[:fail_fast] ||= Integer(ENV["RSPECQ_FAIL_FAST"] || DEFAULT_FAIL_FAST)
-opts[:include_suite_in_filename] ||= env_set?("RSPECQ_INCLUDE_SUITE_IN_FILENAME")
+opts[:output_junit] ||= env_set?("RSPECQ_OUTPUT_JUNIT")
 
 # rubocop:disable Style/RaiseArgs, Layout/EmptyLineAfterGuardClause
 raise OptionParser::MissingArgument.new(:build) if opts[:build].nil?
@@ -164,6 +164,6 @@ else
   worker.file_split_threshold = opts[:file_split_threshold]
   worker.max_requeues = opts[:max_requeues]
   worker.fail_fast = opts[:fail_fast]
-  worker.include_suite_in_filename = opts[:include_suite_in_filename]
+  worker.output_junit = opts[:output_junit]
   worker.work
 end

--- a/bin/rspecq
+++ b/bin/rspecq
@@ -124,6 +124,19 @@ else
   redis_opts[:host] = opts[:redis_host]
 end
 
+# Use the RSpec parser to parse any command line args intended for rspec such
+# as `-- --format JUnit -o foo.xml` so that we can pass these args to rspec
+# while removing the files_or_dirs_to_run since we want to pull those from the
+# queue. OptionParser above mutates ARGV, so only options after `--`  or
+# non-flag arguments (such as files) will make it to this point.
+files_or_dirs_to_run = RSpec::Core::Parser.new(ARGV).parse[:files_or_directories_to_run]
+if files_or_dirs_to_run.length.zero?
+  opts[:rspec_args] = ARGV
+else
+  opts[:rspec_args] = ARGV[0...-files_or_dirs_to_run.length]
+  opts[:files_or_dirs_to_run] = files_or_dirs_to_run
+end
+
 if opts[:report]
   reporter = RSpecQ::Reporter.new(
     build_id: opts[:build],
@@ -139,7 +152,8 @@ else
     redis_opts: redis_opts
   )
 
-  worker.files_or_dirs_to_run = ARGV[0] if ARGV[0]
+  worker.rspec_args = opts[:rspec_args]
+  worker.files_or_dirs_to_run = opts[:files_or_dirs_to_run] if opts[:files_or_dirs_to_run]
   worker.populate_timings = opts[:timings]
   worker.file_split_threshold = opts[:file_split_threshold]
   worker.max_requeues = opts[:max_requeues]

--- a/bin/rspecq
+++ b/bin/rspecq
@@ -89,6 +89,11 @@ OptionParser.new do |o|
     opts[:fail_fast] = v
   end
 
+  o.on("--include-suite-in-filename", "Add suite count to output file names so " \
+    "so that all suites are presented in output files.") do |v|
+    opts[:include_suite_in_filename] = v
+  end
+
   o.on_tail("-h", "--help", "Show this message.") do
     puts o
     exit
@@ -110,6 +115,7 @@ opts[:report_timeout] ||= Integer(ENV["RSPECQ_REPORT_TIMEOUT"] || DEFAULT_REPORT
 opts[:max_requeues] ||= Integer(ENV["RSPECQ_MAX_REQUEUES"] || DEFAULT_MAX_REQUEUES)
 opts[:redis_url] ||= ENV["RSPECQ_REDIS_URL"]
 opts[:fail_fast] ||= Integer(ENV["RSPECQ_FAIL_FAST"] || DEFAULT_FAIL_FAST)
+opts[:include_suite_in_filename] ||= env_set?("RSPECQ_INCLUDE_SUITE_IN_FILENAME")
 
 # rubocop:disable Style/RaiseArgs, Layout/EmptyLineAfterGuardClause
 raise OptionParser::MissingArgument.new(:build) if opts[:build].nil?
@@ -158,5 +164,6 @@ else
   worker.file_split_threshold = opts[:file_split_threshold]
   worker.max_requeues = opts[:max_requeues]
   worker.fail_fast = opts[:fail_fast]
+  worker.include_suite_in_filename = opts[:include_suite_in_filename]
   worker.work
 end

--- a/lib/rspecq.rb
+++ b/lib/rspecq.rb
@@ -11,6 +11,7 @@ end
 require_relative "rspecq/formatters/example_count_recorder"
 require_relative "rspecq/formatters/failure_recorder"
 require_relative "rspecq/formatters/job_timing_recorder"
+require_relative "rspecq/formatters/junit_formatter"
 require_relative "rspecq/formatters/worker_heartbeat_recorder"
 
 require_relative "rspecq/queue"

--- a/lib/rspecq/formatters/junit_formatter.rb
+++ b/lib/rspecq/formatters/junit_formatter.rb
@@ -1,60 +1,29 @@
 require "rspec_junit_formatter"
-require "pry-byebug"
 
 module RSpecQ
   module Formatters
-    # Persists status of examples, so that we can run a single Reporter.
+    # Junit output formatter that handles outputting of requeued examples,
+    # the multiple suites per rspecq run.
     class JUnitFormatter < RSpecJUnitFormatter
-      # def initialize(queue, job, max_requeues)
       def initialize(queue, job, max_requeues, job_index)
         @queue = queue
         @job = job
         @max_requeues = max_requeues
-        @requeued_examples =[]
+        @requeued_examples = []
         path = "test_results/results-#{job_index}.xml"
         RSpec::Support::DirectoryMaker.mkdir_p(File.dirname(path))
         output_file = File.new(path, "w")
         super(output_file)
       end
 
-      def example_passed(notification)
-        log_notification("example_passed", notification)
-      end
-
       def example_failed(notification)
         # if it is requeued, store the notification
-        log_notification("example_failed", notification)
         if @queue.requeueable_job?(notification.example.id, @max_requeues)
-          puts "IGNORE from dump... getting requeued"
           @requeued_examples << notification.example
-        else
-          puts "FAILED - print it in dump"
         end
       end
 
-      def start(notification)
-        log_notification("start", notification)
-        super
-      end
-
-      def stop(notification)
-        log_notification("stop", notification)
-        super
-      end
-
-      def dump_summary(notification)
-        log_notification("dump_summary", notification)
-        super
-      end
-
       private
-
-      def log_notification(event, notification)
-        puts "============"
-        puts event
-        puts notification.inspect
-        puts "============"
-      end
 
       def example_count
         @summary_notification.example_count - @requeued_examples.size

--- a/lib/rspecq/formatters/junit_formatter.rb
+++ b/lib/rspecq/formatters/junit_formatter.rb
@@ -1,0 +1,74 @@
+require "rspec_junit_formatter"
+require "pry-byebug"
+
+module RSpecQ
+  module Formatters
+    # Persists status of examples, so that we can run a single Reporter.
+    class JUnitFormatter < RSpecJUnitFormatter
+      # def initialize(queue, job, max_requeues)
+      def initialize(queue, job, max_requeues, job_index)
+        @queue = queue
+        @job = job
+        @max_requeues = max_requeues
+        @requeued_examples =[]
+        path = "test_results/results-#{job_index}.xml"
+        RSpec::Support::DirectoryMaker.mkdir_p(File.dirname(path))
+        output_file = File.new(path, "w")
+        super(output_file)
+      end
+
+      def example_passed(notification)
+        log_notification("example_passed", notification)
+      end
+
+      def example_failed(notification)
+        # if it is requeued, store the notification
+        log_notification("example_failed", notification)
+        if @queue.requeueable_job?(notification.example.id, @max_requeues)
+          puts "IGNORE from dump... getting requeued"
+          @requeued_examples << notification.example
+        else
+          puts "FAILED - print it in dump"
+        end
+      end
+
+      def start(notification)
+        log_notification("start", notification)
+        super
+      end
+
+      def stop(notification)
+        log_notification("stop", notification)
+        super
+      end
+
+      def dump_summary(notification)
+        log_notification("dump_summary", notification)
+        super
+      end
+
+      private
+
+      def log_notification(event, notification)
+        puts "============"
+        puts event
+        puts notification.inspect
+        puts "============"
+      end
+
+      def example_count
+        @summary_notification.example_count - @requeued_examples.size
+      end
+
+      def failure_count
+        @summary_notification.failure_count - @requeued_examples.size
+      end
+
+      def examples
+        @examples_notification.notifications.reject do |example_notification|
+          @requeued_examples.include?(example_notification.example)
+        end
+      end
+    end
+  end
+end

--- a/lib/rspecq/worker.rb
+++ b/lib/rspecq/worker.rb
@@ -46,6 +46,11 @@ module RSpecQ
     # Defaults to 0
     attr_accessor :fail_fast
 
+    # Optional arguments to pass along to rspec.
+    #
+    # Defaults to nil
+    attr_accessor :rspec_args
+
     attr_reader :queue
 
     def initialize(build_id:, worker_id:, redis_opts:)
@@ -107,7 +112,8 @@ module RSpecQ
           RSpec.configuration.add_formatter(Formatters::JobTimingRecorder.new(queue, job))
         end
 
-        opts = RSpec::Core::ConfigurationOptions.new(["--format", "progress", job])
+        args = [*rspec_args, "--format", "progress", job]
+        opts = RSpec::Core::ConfigurationOptions.new(args)
         _result = RSpec::Core::Runner.new(opts).run($stderr, $stdout)
 
         queue.acknowledge_job(job)

--- a/lib/rspecq/worker.rb
+++ b/lib/rspecq/worker.rb
@@ -46,6 +46,11 @@ module RSpecQ
     # Defaults to 0
     attr_accessor :fail_fast
 
+    # Include a suite counter in any output filenames so that each suite run
+    #
+    # Defaults to false
+    attr_accessor :include_suite_in_filename
+
     # Optional arguments to pass along to rspec.
     #
     # Defaults to nil
@@ -63,6 +68,7 @@ module RSpecQ
       @file_split_threshold = 999_999
       @heartbeat_updated_at = nil
       @max_requeues = 3
+      @include_suite_in_filename = false
 
       RSpec::Core::Formatters.register(Formatters::JobTimingRecorder, :dump_summary)
       RSpec::Core::Formatters.register(Formatters::ExampleCountRecorder, :dump_summary)
@@ -115,12 +121,10 @@ module RSpecQ
         args = [*rspec_args, "--format", "progress", job]
         opts = RSpec::Core::ConfigurationOptions.new(args)
 
-        junit_formatter = opts.options[:formatters].find { |formatter| formatter[0] == "RspecJunitFormatter" }
-        if junit_formatter
-          opts.options[:formatters].delete(junit_formatter)
-          output_file = junit_formatter[1].split(".")
-          opts.options[:formatters] << ["RspecJunitFormatter", "#{output_file.first}-job-#{idx}.#{output_file.last}"]
+        if include_suite_in_filename?
+          add_suite_index_to_output_filename(opts, idx)
         end
+
         _result = RSpec::Core::Runner.new(opts).run($stderr, $stdout)
 
         queue.acknowledge_job(job)
@@ -265,6 +269,20 @@ module RSpecQ
         object: inspect,
         pid: Process.pid
       }.merge(additional))
+    end
+
+    def include_suite_in_filename?
+      include_suite_in_filename
+    end
+
+    def add_suite_index_to_output_filename(rspec_options, suite_index)
+      formatters = rspec_options.options[:formatters].select { |formatter| formatter.size == 2 }
+      formatters.each do |formatter|
+        rspec_options.options[:formatters].delete(formatter)
+        file_extension = File.extname(formatter[1])
+        modified_filename = formatter[1].gsub(/#{file_extension}$/, "-#{suite_index}#{file_extension}")
+        rspec_options.options[:formatters] << [formatter[0], modified_filename]
+      end
     end
   end
 end

--- a/lib/rspecq/worker.rb
+++ b/lib/rspecq/worker.rb
@@ -74,6 +74,8 @@ module RSpecQ
       RSpec::Core::Formatters.register(Formatters::ExampleCountRecorder, :dump_summary)
       RSpec::Core::Formatters.register(Formatters::FailureRecorder, :example_failed, :message)
       RSpec::Core::Formatters.register(Formatters::WorkerHeartbeatRecorder, :example_finished)
+      RSpec::Core::Formatters.register(Formatters::JUnitFormatter, :example_failed, :example_passed, :start, :stop, :dump_summary)
+
     end
 
     def work
@@ -110,6 +112,7 @@ module RSpecQ
         RSpec.configuration.detail_color = :magenta
         RSpec.configuration.seed = srand && srand % 0xFFFF
         RSpec.configuration.backtrace_formatter.filter_gem("rspecq")
+        RSpec.configuration.add_formatter(Formatters::JUnitFormatter.new(queue, job, max_requeues, idx))
         RSpec.configuration.add_formatter(Formatters::FailureRecorder.new(queue, job, max_requeues))
         RSpec.configuration.add_formatter(Formatters::ExampleCountRecorder.new(queue))
         RSpec.configuration.add_formatter(Formatters::WorkerHeartbeatRecorder.new(self))
@@ -124,6 +127,8 @@ module RSpecQ
         if include_suite_in_filename?
           add_suite_index_to_output_filename(opts, idx)
         end
+
+        puts RSpec::Core::Formatters::Loader.formatters.inspect
 
         _result = RSpec::Core::Runner.new(opts).run($stderr, $stdout)
 

--- a/lib/rspecq/worker.rb
+++ b/lib/rspecq/worker.rb
@@ -128,8 +128,8 @@ module RSpecQ
         _result = RSpec::Core::Runner.new(opts).run($stderr, $stdout)
 
         queue.acknowledge_job(job)
+        idx += 1
       end
-      idx += 1
     end
 
     # Update the worker heartbeat if necessary

--- a/rspecq.gemspec
+++ b/rspecq.gemspec
@@ -20,6 +20,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency "redis"
   s.add_dependency "sentry-raven"
+  s.add_dependency "rspec_junit_formatter"
 
   s.add_development_dependency "minitest"
   s.add_development_dependency "pry-byebug"

--- a/test/sample_suites/tagged_suite/spec/tagged_spec.rb
+++ b/test/sample_suites/tagged_suite/spec/tagged_spec.rb
@@ -1,0 +1,4 @@
+RSpec.describe do
+  it("foo", :foo) { expect(true).to be true }
+  it("bar", :bar) { expect(true).to be true }
+end

--- a/test/test_e2e.rb
+++ b/test/test_e2e.rb
@@ -129,4 +129,10 @@ class TestEndToEnd < RSpecQTest
 
     assert_includes [2, 3], queue.processed_jobs.length
   end
+
+  def test_suite_with_rspec_arguments
+    queue = exec_build("tagged_suite", "-- --tag foo")
+
+    assert_equal 1, queue.example_count
+  end
 end


### PR DESCRIPTION
Add support for outputting junit formatted xml that handles the multiple suites per rspecq run, handles the potential for retries, and updates outputted xml appropriately.