### PR TITLE
Expose the queue ready timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ OPTIONS:
                                      Exits with a non-zero status code if there were any failures.
         --report-timeout N           Fail if build is not finished after N seconds. Only applicable if --report is enabled (default: 3600).
         --max-requeues N             Retry failed examples up to N times before considering them legit failures (default: 3).
+        --queue-wait-timeout N       Time to wait for a queue to be ready before considering it failed (default: 30).
         --fail-fast N                Abort build with a non-zero status code after N failed examples.
     -h, --help                       Show this message.
     -v, --version                    Print the version and exit.

--- a/bin/rspecq
+++ b/bin/rspecq
@@ -5,6 +5,7 @@ require "rspecq"
 DEFAULT_REDIS_HOST = "127.0.0.1".freeze
 DEFAULT_REPORT_TIMEOUT = 3600 # 1 hour
 DEFAULT_MAX_REQUEUES = 3
+DEFAULT_QUEUE_WAIT_TIMEOUT = 30
 DEFAULT_FAIL_FAST = 0
 
 def env_set?(var)
@@ -84,6 +85,12 @@ OptionParser.new do |o|
     opts[:max_requeues] = v
   end
 
+  o.on("--queue-wait-timeout N", Integer, "Time to wait for a queue to be "   \
+       "ready before considering it failed "                                  \
+       "(default: #{DEFAULT_QUEUE_WAIT_TIMEOUT}).") do |v|
+    opts[:queue_wait_timeout] = v
+  end
+
   o.on("--fail-fast N", Integer, "Abort build with a non-zero status code " \
        "after N failed examples.") do |v|
     opts[:fail_fast] = v
@@ -108,6 +115,7 @@ opts[:file_split_threshold] ||= Integer(ENV["RSPECQ_FILE_SPLIT_THRESHOLD"] || 9_
 opts[:report] ||= env_set?("RSPECQ_REPORT")
 opts[:report_timeout] ||= Integer(ENV["RSPECQ_REPORT_TIMEOUT"] || DEFAULT_REPORT_TIMEOUT)
 opts[:max_requeues] ||= Integer(ENV["RSPECQ_MAX_REQUEUES"] || DEFAULT_MAX_REQUEUES)
+opts[:queue_wait_timeout] ||= Integer(ENV["RSPECQ_QUEUE_WAIT_TIMEOUT"] || DEFAULT_QUEUE_WAIT_TIMEOUT)
 opts[:redis_url] ||= ENV["RSPECQ_REDIS_URL"]
 opts[:fail_fast] ||= Integer(ENV["RSPECQ_FAIL_FAST"] || DEFAULT_FAIL_FAST)
 
@@ -128,7 +136,8 @@ if opts[:report]
   reporter = RSpecQ::Reporter.new(
     build_id: opts[:build],
     timeout: opts[:report_timeout],
-    redis_opts: redis_opts
+    redis_opts: redis_opts,
+    queue_wait_timeout: opts[:queue_wait_timeout]
   )
 
   reporter.report
@@ -143,6 +152,7 @@ else
   worker.populate_timings = opts[:timings]
   worker.file_split_threshold = opts[:file_split_threshold]
   worker.max_requeues = opts[:max_requeues]
+  worker.queue_wait_timeout = opts[:queue_wait_timeout]
   worker.fail_fast = opts[:fail_fast]
   worker.work
 end

--- a/lib/rspecq/reporter.rb
+++ b/lib/rspecq/reporter.rb
@@ -9,10 +9,11 @@ module RSpecQ
   #
   # Reporters are readers of the queue.
   class Reporter
-    def initialize(build_id:, timeout:, redis_opts:)
+    def initialize(build_id:, timeout:, redis_opts:, queue_wait_timeout: 30)
       @build_id = build_id
       @timeout = timeout
       @queue = Queue.new(build_id, "reporter", redis_opts)
+      @queue_wait_timeout = queue_wait_timeout
 
       # We want feedback to be immediattely printed to CI users, so
       # we disable buffering.
@@ -20,7 +21,7 @@ module RSpecQ
     end
 
     def report
-      @queue.wait_until_published
+      @queue.wait_until_published(@queue_wait_timeout)
 
       finished = false
 

--- a/lib/rspecq/worker.rb
+++ b/lib/rspecq/worker.rb
@@ -46,6 +46,11 @@ module RSpecQ
     # Defaults to 0
     attr_accessor :fail_fast
 
+    # Time to wait for a queue to be published.
+    #
+    # Defaults to 30
+    attr_accessor :queue_wait_timeout
+
     attr_reader :queue
 
     def initialize(build_id:, worker_id:, redis_opts:)
@@ -58,6 +63,7 @@ module RSpecQ
       @file_split_threshold = 999_999
       @heartbeat_updated_at = nil
       @max_requeues = 3
+      @queue_wait_timeout = 30
 
       RSpec::Core::Formatters.register(Formatters::JobTimingRecorder, :dump_summary)
       RSpec::Core::Formatters.register(Formatters::ExampleCountRecorder, :dump_summary)
@@ -69,7 +75,7 @@ module RSpecQ
       puts "Working for build #{@build_id} (worker=#{@worker_id})"
 
       try_publish_queue!(queue)
-      queue.wait_until_published
+      queue.wait_until_published(queue_wait_timeout)
 
       loop do
         # we have to bootstrap this so that it can be used in the first call


### PR DESCRIPTION
This commit exposes the timeout we use to consider a queue failed
(not ready).

The need for this was triggered after using rspecq on a host
with lower specs.