### PR TITLE
Increase visibitility into flaky tests

### DIFF
--- a/lib/rspecq/formatters/failure_recorder.rb
+++ b/lib/rspecq/formatters/failure_recorder.rb
@@ -31,6 +31,13 @@ module RSpecQ
         example = notification.example
 
         if @queue.requeue_job(example.id, @max_requeues)
+
+          # Save the rerun command for later. It will be used if this is
+          # a flaky test for more user-friendly reporting.
+
+          rerun_cmd = "bin/rspec #{example.location_rerun_argument}"
+          @queue.save_rerun_command(example.id, rerun_cmd)
+
           # HACK: try to avoid picking the job we just requeued; we want it
           # to be picked up by a different worker
           sleep 0.5

--- a/lib/rspecq/queue.rb
+++ b/lib/rspecq/queue.rb
@@ -135,6 +135,14 @@ module RSpecQ
       )
     end
 
+    def save_rerun_command(job, location)
+      @redis.hset(key("job_metadata"), job, location)
+    end
+
+    def rerun_command(job)
+      @redis.hget(key("job_metadata"), job)
+    end
+
     def record_example_failure(example_id, message)
       @redis.hset(key_failures, example_id, message)
     end

--- a/lib/rspecq/reporter.rb
+++ b/lib/rspecq/reporter.rb
@@ -56,7 +56,7 @@ module RSpecQ
 
       @queue.record_build_time(tests_duration)
 
-      flaky_jobs = @queue.flaky_jobs
+      flaky_jobs = @queue.flaky_jobs.map { |job| @queue.rerun_command(job) }
 
       puts summary(@queue.example_failures, @queue.non_example_errors,
         flaky_jobs, humanize_duration(tests_duration))

--- a/test/test_reporter.rb
+++ b/test/test_reporter.rb
@@ -30,7 +30,7 @@ class TestReporter < RSpecQTest
     output = exec_reporter(build_id: build_id)
 
     assert_match "Flaky jobs detected", output
-    assert_match "./spec/foo_spec.rb[1:1]", output
+    assert_match "bin/rspec ./spec/foo_spec.rb:2", output
     refute_match "Failed examples", output
   end
 end


### PR DESCRIPTION
Expose rspec example's location instead of the id.

For example, when reporting flaky tests, instead of printing

```
./spec/foo_spec.rb[1:13:1:2:2:1]
```

it will print

```
./spec/foo_spec.rb:15
```

This will allow the developers to reproduce the tests.