### PR TITLE
Improve reporting for failing test reproduction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,11 @@
 # Changelog
 
+Breaking changes are prefixed with a "[BREAKING]" label.
+
 ## master (unreleased)
 
-Breaking changes are prefixed with a "[BREAKING]" label.
+- New cli parameter `seed`.
+  The seed is passed to the RSpec command.
 
 ## 0.5.0 (2021-02-05)
 

--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ $ RSPECQ_BUILD=123 RSPECQ_WORKDER=foo1 rspecq spec/
 | --- | --- |
 | `RSPECQ_BUILD` | Build ID |
 | `RSPECQ_WORKER` | Worker ID |
+| `RSPECQ_SEED` | RSpec seed |
 | `RSPECQ_REDIS` | Redis HOST |
 | `RSPECQ_UPDATE_TIMINGS` | Timings |
 | `RSPECQ_FILE_SPLIT_THRESHOLD` | File split threshold |

--- a/bin/rspecq
+++ b/bin/rspecq
@@ -38,6 +38,11 @@ OptionParser.new do |o|
     opts[:worker] = v
   end
 
+  o.on("--seed SEED", "The RSpec seed. Passing the seed can be helpful in " \
+    "many ways i.e reproduction and testing.") do |v|
+    opts[:seed] = v
+  end
+
   o.on("-r", "--redis HOST", "Redis host to connect to " \
        "(default: #{DEFAULT_REDIS_HOST}).") do |v|
     puts "DEPRECATION: --redis is deprecated. Use --redis-host or --redis-url instead"
@@ -109,6 +114,7 @@ end.parse!
 
 opts[:build] ||= ENV["RSPECQ_BUILD"]
 opts[:worker] ||= ENV["RSPECQ_WORKER"]
+opts[:seed] ||= ENV["RSPECQ_SEED"]
 opts[:redis_host] ||= ENV["RSPECQ_REDIS"] || DEFAULT_REDIS_HOST
 opts[:timings] ||= env_set?("RSPECQ_UPDATE_TIMINGS")
 opts[:file_split_threshold] ||= Integer(ENV["RSPECQ_FILE_SPLIT_THRESHOLD"] || 9_999_999)
@@ -154,5 +160,6 @@ else
   worker.max_requeues = opts[:max_requeues]
   worker.queue_wait_timeout = opts[:queue_wait_timeout]
   worker.fail_fast = opts[:fail_fast]
+  worker.seed = Integer(opts[:seed]) if opts[:seed]
   worker.work
 end

--- a/lib/rspecq/formatters/failure_recorder.rb
+++ b/lib/rspecq/formatters/failure_recorder.rb
@@ -44,7 +44,7 @@ module RSpecQ
         msg = presenter.fully_formatted(nil, @colorizer)
         msg << "\n"
         msg << @colorizer.wrap(
-          "bin/rspec #{example.location_rerun_argument}",
+          "bin/rspec --seed #{RSpec.configuration.seed} #{example.location_rerun_argument}",
           RSpec.configuration.failure_color
         )
 

--- a/lib/rspecq/formatters/failure_recorder.rb
+++ b/lib/rspecq/formatters/failure_recorder.rb
@@ -30,7 +30,14 @@ module RSpecQ
       def example_failed(notification)
         example = notification.example
 
+        rerun_cmd = "bin/rspec --seed #{RSpec.configuration.seed} #{example.location_rerun_argument}"
+
         if @queue.requeue_job(example.id, @max_requeues)
+
+          # Save the rerun command for later. It will be used if this is
+          # a flaky test for more user-friendly reporting.
+          @queue.save_rerun_command(example.id, rerun_cmd)
+
           # HACK: try to avoid picking the job we just requeued; we want it
           # to be picked up by a different worker
           sleep 0.5
@@ -44,7 +51,7 @@ module RSpecQ
         msg = presenter.fully_formatted(nil, @colorizer)
         msg << "\n"
         msg << @colorizer.wrap(
-          "bin/rspec --seed #{RSpec.configuration.seed} #{example.location_rerun_argument}",
+          rerun_cmd,
           RSpec.configuration.failure_color
         )
 

--- a/lib/rspecq/queue.rb
+++ b/lib/rspecq/queue.rb
@@ -135,6 +135,14 @@ module RSpecQ
       )
     end
 
+    def save_rerun_command(job, cmd)
+      @redis.hset(key("job_metadata"), job, cmd)
+    end
+
+    def rerun_command(job)
+      @redis.hget(key("job_metadata"), job)
+    end
+
     def record_example_failure(example_id, message)
       @redis.hset(key_failures, example_id, message)
     end

--- a/lib/rspecq/reporter.rb
+++ b/lib/rspecq/reporter.rb
@@ -56,7 +56,7 @@ module RSpecQ
 
       @queue.record_build_time(tests_duration)
 
-      flaky_jobs = @queue.flaky_jobs
+      flaky_jobs = @queue.flaky_jobs.map { |job| @queue.rerun_command(job) }
 
       puts summary(@queue.example_failures, @queue.non_example_errors,
         flaky_jobs, humanize_duration(tests_duration))
@@ -107,7 +107,12 @@ module RSpecQ
       if !flaky_jobs.empty?
         summary << "\n\n"
         summary << "Flaky jobs detected (count=#{flaky_jobs.count}):\n"
-        flaky_jobs.each { |j| summary << "  #{j}\n" }
+        flaky_jobs.each do |j|
+          summary << RSpec::Core::Formatters::ConsoleCodes.wrap(
+            "#{j}\n",
+            RSpec.configuration.pending_color
+          )
+        end
       end
 
       summary

--- a/lib/rspecq/worker.rb
+++ b/lib/rspecq/worker.rb
@@ -51,6 +51,9 @@ module RSpecQ
     # Defaults to 30
     attr_accessor :queue_wait_timeout
 
+    # The RSpec seed
+    attr_accessor :seed
+
     attr_reader :queue
 
     def initialize(build_id:, worker_id:, redis_opts:)
@@ -64,6 +67,7 @@ module RSpecQ
       @heartbeat_updated_at = nil
       @max_requeues = 3
       @queue_wait_timeout = 30
+      @seed = srand && srand % 0xFFFF
 
       RSpec::Core::Formatters.register(Formatters::JobTimingRecorder, :dump_summary)
       RSpec::Core::Formatters.register(Formatters::ExampleCountRecorder, :dump_summary)
@@ -103,7 +107,7 @@ module RSpecQ
 
         # reconfigure rspec
         RSpec.configuration.detail_color = :magenta
-        RSpec.configuration.seed = srand && srand % 0xFFFF
+        RSpec.configuration.seed = seed
         RSpec.configuration.backtrace_formatter.filter_gem("rspecq")
         RSpec.configuration.add_formatter(Formatters::FailureRecorder.new(queue, job, max_requeues))
         RSpec.configuration.add_formatter(Formatters::ExampleCountRecorder.new(queue))

--- a/test/test_reporter.rb
+++ b/test/test_reporter.rb
@@ -26,11 +26,11 @@ class TestReporter < RSpecQTest
 
   def test_flakey_suite
     build_id = rand_id
-    exec_build("flakey_suite", "", build_id: build_id)
+    exec_build("flakey_suite", "--seed 1234", build_id: build_id)
     output = exec_reporter(build_id: build_id)
 
     assert_match "Flaky jobs detected", output
-    assert_match "./spec/foo_spec.rb[1:1]", output
+    assert_match "bin/rspec --seed 1234 ./spec/foo_spec.rb:2", output
     refute_match "Failed examples", output
   end
 end

--- a/test/test_reporter.rb
+++ b/test/test_reporter.rb
@@ -16,11 +16,11 @@ class TestReporter < RSpecQTest
 
   def test_failing_suite
     build_id = rand_id
-    exec_build("failing_suite", "", build_id: build_id)
+    exec_build("failing_suite", "--seed 1234", build_id: build_id)
     output = exec_reporter(build_id: build_id)
 
     assert_match "Failed examples", output
-    assert_match "bin/rspec ./spec/fail_1_spec.rb:3", output
+    assert_match "bin/rspec --seed 1234 ./spec/fail_1_spec.rb:3", output
     refute_match "Flaky", output
   end
 


### PR DESCRIPTION
RSpecQ currently does not report the rspec seed. This makes failure reproduction difficult especially regarding the flakey tests.
The PR does a couple of things.

1. Exposes the seed to the report for failed and flakey tests.
1. Print flakey tests rerun location `./spec/foo_spec.rb:15` instead of test id `./spec/foo_spec.rb:[1:13:1:2:2:1]`

A note regarding flakey tets.

RSpecQ workers run tests by pulling from the queue. The queue contains either files (with many tests) or individual tests, depending on the timing split. This means that if a test is marked as flakey by the worker, it was run as part of the file it belongs to (most likely) or it was run in itself.

Knowledge of the above fact allows us to conclude that having the knowledge of the **seed** and the **spec line** (aka rerun location) is enough to reproduce a flakey test.

In addition to the above, the PR also adds a new cli parameter `seed` which in general allows the client that executes a worker to use a specific seed. This may have many use-cases, but we use it the test suite to check that the reporter's output is correct.