### PR TITLE
Display more information regarding flaky tests

### DIFF
--- a/lib/rspecq/formatters/failure_recorder.rb
+++ b/lib/rspecq/formatters/failure_recorder.rb
@@ -6,12 +6,13 @@ module RSpecQ
     # Also persists non-example error information (e.g. a syntax error that
     # in a spec file).
     class FailureRecorder
-      def initialize(queue, job, max_requeues)
+      def initialize(queue, job, max_requeues, worker_id)
         @queue = queue
         @job = job
         @colorizer = RSpec::Core::Formatters::ConsoleCodes
         @non_example_error_recorded = false
         @max_requeues = max_requeues
+        @worker_id = worker_id
       end
 
       # Here we're notified about errors occuring outside of examples.
@@ -30,13 +31,19 @@ module RSpecQ
       def example_failed(notification)
         example = notification.example
 
-        rerun_cmd = "bin/rspec --seed #{RSpec.configuration.seed} #{example.location_rerun_argument}"
+        presenter = RSpec::Core::Formatters::ExceptionPresenter.new(
+          example.exception, example
+        )
 
         if @queue.requeue_job(example.id, @max_requeues)
 
-          # Save the rerun command for later. It will be used if this is
-          # a flaky test for more user-friendly reporting.
-          @queue.save_rerun_command(example.id, rerun_cmd)
+          # Save the rerun command and other metadata for later. They will be
+          # used if this is a flaky test for more user-friendly reporting.
+          @queue.save_job_metadata(example.id, "location", example.location_rerun_argument)
+          @queue.save_job_metadata(example.id, "seed", RSpec.configuration.seed)
+          @queue.save_job_metadata(example.id, "failure_reason", presenter.message_lines.join("\n"))
+          @queue.save_job_metadata(example.id, "backtrace", presenter.formatted_backtrace.join("\n"))
+          @queue.save_job_metadata(example.id, "worker_id", @worker_id)
 
           # HACK: try to avoid picking the job we just requeued; we want it
           # to be picked up by a different worker
@@ -44,14 +51,10 @@ module RSpecQ
           return
         end
 
-        presenter = RSpec::Core::Formatters::ExceptionPresenter.new(
-          example.exception, example
-        )
-
         msg = presenter.fully_formatted(nil, @colorizer)
         msg << "\n"
         msg << @colorizer.wrap(
-          rerun_cmd,
+          "bin/rspec #{example.location_rerun_argument}",
           RSpec.configuration.failure_color
         )
 

--- a/lib/rspecq/queue.rb
+++ b/lib/rspecq/queue.rb
@@ -135,12 +135,14 @@ module RSpecQ
       )
     end
 
-    def save_rerun_command(job, cmd)
-      @redis.hset(key("job_metadata"), job, cmd)
+    # General purpose method.
+    # Used to save metadata regarding a job, i.e its backtrace.
+    def save_job_metadata(job, key, value)
+      @redis.hset(key("job_metadata"), "#{job}_#{key}", value)
     end
 
-    def rerun_command(job)
-      @redis.hget(key("job_metadata"), job)
+    def job_metadata(job, key)
+      @redis.hget(key("job_metadata"), "#{job}_#{key}")
     end
 
     def record_example_failure(example_id, message)

--- a/lib/rspecq/reporter.rb
+++ b/lib/rspecq/reporter.rb
@@ -135,11 +135,8 @@ module RSpecQ
         extra = {
           build: @build_id,
           build_timeout: @timeout,
-          queue: @queue.inspect,
-          object: inspect,
-          pid: Process.pid,
+          build_duration: build_duration,
           rerun_command: job,
-          build_duration: build_duration
         }
 
         tags = {

--- a/lib/rspecq/worker.rb
+++ b/lib/rspecq/worker.rb
@@ -109,7 +109,7 @@ module RSpecQ
         RSpec.configuration.detail_color = :magenta
         RSpec.configuration.seed = seed
         RSpec.configuration.backtrace_formatter.filter_gem("rspecq")
-        RSpec.configuration.add_formatter(Formatters::FailureRecorder.new(queue, job, max_requeues))
+        RSpec.configuration.add_formatter(Formatters::FailureRecorder.new(queue, job, max_requeues, @worker_id))
         RSpec.configuration.add_formatter(Formatters::ExampleCountRecorder.new(queue))
         RSpec.configuration.add_formatter(Formatters::WorkerHeartbeatRecorder.new(self))
 

--- a/test/test_reporter.rb
+++ b/test/test_reporter.rb
@@ -20,7 +20,7 @@ class TestReporter < RSpecQTest
     output = exec_reporter(build_id: build_id)
 
     assert_match "Failed examples", output
-    assert_match "bin/rspec --seed 1234 ./spec/fail_1_spec.rb:3", output
+    assert_match "bin/rspec ./spec/fail_1_spec.rb:3", output
     refute_match "Flaky", output
   end
 
@@ -30,7 +30,7 @@ class TestReporter < RSpecQTest
     output = exec_reporter(build_id: build_id)
 
     assert_match "Flaky jobs detected", output
-    assert_match "bin/rspec --seed 1234 ./spec/foo_spec.rb:2", output
+    assert_match "./spec/foo_spec.rb:2", output
     refute_match "Failed examples", output
   end
 end


### PR DESCRIPTION
Flaky tests may fail, but the rspec output is lost in the process.

This commit enriches the sentry event with the spec seed, expectation,
backtrace, as well as with the id of the worker in which the spec failed.

The devs can see what was expected but most importantly what was produced.

This is a temporary solution until we introduce a better way to capture the
distributed worker outputs and provide a true and easy way to reproduce the
flaky tests.

We drop the rerun commands entirely since they are not successful in
correctly reproducing the errors are I originally thought. We go back to a
simpler reporter output.