### PR TITLE
Help users reproduce flaky tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ OPTIONS:
         --max-requeues N             Retry failed examples up to N times before considering them legit failures (default: 3).
         --queue-wait-timeout N       Time to wait for a queue to be ready before considering it failed (default: 30).
         --fail-fast N                Abort build with a non-zero status code after N failed examples.
+        --reproduction               Enable reproduction mode: Publish files and examples in the exact order given in the command. Incompatible with --timings.
     -h, --help                       Show this message.
     -v, --version                    Print the version and exit.
 ```

--- a/bin/rspecq
+++ b/bin/rspecq
@@ -101,6 +101,12 @@ OptionParser.new do |o|
     opts[:fail_fast] = v
   end
 
+  o.on("--reproduction", "Enable reproduction mode: run rspec on the given files " \
+       "and examples in the exact order they are given. Incompatible with " \
+       "--timings.") do |v|
+    opts[:reproduction] = v
+  end
+
   o.on_tail("-h", "--help", "Show this message.") do
     puts o
     exit
@@ -124,6 +130,7 @@ opts[:max_requeues] ||= Integer(ENV["RSPECQ_MAX_REQUEUES"] || DEFAULT_MAX_REQUEU
 opts[:queue_wait_timeout] ||= Integer(ENV["RSPECQ_QUEUE_WAIT_TIMEOUT"] || DEFAULT_QUEUE_WAIT_TIMEOUT)
 opts[:redis_url] ||= ENV["RSPECQ_REDIS_URL"]
 opts[:fail_fast] ||= Integer(ENV["RSPECQ_FAIL_FAST"] || DEFAULT_FAIL_FAST)
+opts[:reproduction] ||= env_set?("RSPECQ_REPRODUCTION")
 
 # rubocop:disable Style/RaiseArgs, Layout/EmptyLineAfterGuardClause
 raise OptionParser::MissingArgument.new(:build) if opts[:build].nil?
@@ -161,5 +168,6 @@ else
   worker.queue_wait_timeout = opts[:queue_wait_timeout]
   worker.fail_fast = opts[:fail_fast]
   worker.seed = Integer(opts[:seed]) if opts[:seed]
+  worker.reproduction = opts[:reproduction]
   worker.work
 end

--- a/lib/rspecq/formatters/failure_recorder.rb
+++ b/lib/rspecq/formatters/failure_recorder.rb
@@ -30,14 +30,7 @@ module RSpecQ
       def example_failed(notification)
         example = notification.example
 
-        rerun_cmd = "bin/rspec --seed #{RSpec.configuration.seed} #{example.location_rerun_argument}"
-
         if @queue.requeue_job(example.id, @max_requeues)
-
-          # Save the rerun command for later. It will be used if this is
-          # a flaky test for more user-friendly reporting.
-          @queue.save_rerun_command(example.id, rerun_cmd)
-
           # HACK: try to avoid picking the job we just requeued; we want it
           # to be picked up by a different worker
           sleep 0.5
@@ -51,7 +44,7 @@ module RSpecQ
         msg = presenter.fully_formatted(nil, @colorizer)
         msg << "\n"
         msg << @colorizer.wrap(
-          rerun_cmd,
+          "bin/rspec --seed #{RSpec.configuration.seed} #{example.location_rerun_argument}",
           RSpec.configuration.failure_color
         )
 

--- a/lib/rspecq/formatters/failure_recorder.rb
+++ b/lib/rspecq/formatters/failure_recorder.rb
@@ -6,12 +6,13 @@ module RSpecQ
     # Also persists non-example error information (e.g. a syntax error that
     # in a spec file).
     class FailureRecorder
-      def initialize(queue, job, max_requeues)
+      def initialize(queue, job, max_requeues, worker_id)
         @queue = queue
         @job = job
         @colorizer = RSpec::Core::Formatters::ConsoleCodes
         @non_example_error_recorded = false
         @max_requeues = max_requeues
+        @worker_id = worker_id
       end
 
       # Here we're notified about errors occuring outside of examples.
@@ -30,7 +31,7 @@ module RSpecQ
       def example_failed(notification)
         example = notification.example
 
-        if @queue.requeue_job(example.id, @max_requeues)
+        if @queue.requeue_job(example, @max_requeues, @worker_id)
           # HACK: try to avoid picking the job we just requeued; we want it
           # to be picked up by a different worker
           sleep 0.5

--- a/lib/rspecq/queue.rb
+++ b/lib/rspecq/queue.rb
@@ -135,14 +135,6 @@ module RSpecQ
       )
     end
 
-    def save_rerun_command(job, cmd)
-      @redis.hset(key("job_metadata"), job, cmd)
-    end
-
-    def rerun_command(job)
-      @redis.hget(key("job_metadata"), job)
-    end
-
     def record_example_failure(example_id, message)
       @redis.hset(key_failures, example_id, message)
     end

--- a/lib/rspecq/reporter.rb
+++ b/lib/rspecq/reporter.rb
@@ -107,7 +107,14 @@ module RSpecQ
       if !flaky_jobs.empty?
         summary << "\n\n"
         summary << "Flaky jobs detected (count=#{flaky_jobs.count}):\n"
-        flaky_jobs.each { |j| summary << "  #{j}\n" }
+        flaky_jobs.each do |j|
+          summary << RSpec::Core::Formatters::ConsoleCodes.wrap(
+            "#{@queue.job_location(j)} @ #{@queue.failed_job_worker(j)}\n",
+            RSpec.configuration.pending_color
+          )
+
+          summary << "#{@queue.job_rerun_command(j)}\n\n\n"
+        end
       end
 
       summary
@@ -131,7 +138,9 @@ module RSpecQ
           build: @build_id,
           build_timeout: @timeout,
           build_duration: build_duration,
-          rerun_command: job,
+          location: @queue.job_location(job),
+          rerun_command: @queue.job_rerun_command(job),
+          worker: @queue.failed_job_worker(job)
         }
 
         tags = {

--- a/lib/rspecq/reporter.rb
+++ b/lib/rspecq/reporter.rb
@@ -56,7 +56,7 @@ module RSpecQ
 
       @queue.record_build_time(tests_duration)
 
-      flaky_jobs = @queue.flaky_jobs.map { |job| @queue.rerun_command(job) }
+      flaky_jobs = @queue.flaky_jobs
 
       puts summary(@queue.example_failures, @queue.non_example_errors,
         flaky_jobs, humanize_duration(tests_duration))
@@ -107,12 +107,7 @@ module RSpecQ
       if !flaky_jobs.empty?
         summary << "\n\n"
         summary << "Flaky jobs detected (count=#{flaky_jobs.count}):\n"
-        flaky_jobs.each do |j|
-          summary << RSpec::Core::Formatters::ConsoleCodes.wrap(
-            "#{j}\n",
-            RSpec.configuration.pending_color
-          )
-        end
+        flaky_jobs.each { |j| summary << "  #{j}\n" }
       end
 
       summary

--- a/lib/rspecq/worker.rb
+++ b/lib/rspecq/worker.rb
@@ -85,6 +85,7 @@ module RSpecQ
 
       try_publish_queue!(queue)
       queue.wait_until_published(queue_wait_timeout)
+      queue.save_worker_seed(@worker_id, seed)
 
       loop do
         # we have to bootstrap this so that it can be used in the first call
@@ -114,7 +115,7 @@ module RSpecQ
         RSpec.configuration.detail_color = :magenta
         RSpec.configuration.seed = seed
         RSpec.configuration.backtrace_formatter.filter_gem("rspecq")
-        RSpec.configuration.add_formatter(Formatters::FailureRecorder.new(queue, job, max_requeues))
+        RSpec.configuration.add_formatter(Formatters::FailureRecorder.new(queue, job, max_requeues, @worker_id))
         RSpec.configuration.add_formatter(Formatters::ExampleCountRecorder.new(queue))
         RSpec.configuration.add_formatter(Formatters::WorkerHeartbeatRecorder.new(self))
 

--- a/test/test_helpers.rb
+++ b/test/test_helpers.rb
@@ -27,8 +27,8 @@ module TestHelpers
   #   Alternatively you can pass the build_id in case you need to share it
   #   with the reporter.
   # @return [RSpecQ::Queue]
-  def exec_build(path, args = "", build_id: nil)
-    worker_id = rand_id
+  def exec_build(path, args = "", build_id: nil, worker_id: nil)
+    worker_id ||= rand_id
     build_id ||= rand_id
 
     Dir.chdir(suite_path(path)) do

--- a/test/test_reporter.rb
+++ b/test/test_reporter.rb
@@ -26,11 +26,11 @@ class TestReporter < RSpecQTest
 
   def test_flakey_suite
     build_id = rand_id
-    exec_build("flakey_suite", "--seed 1234", build_id: build_id)
+    exec_build("flakey_suite", "", build_id: build_id)
     output = exec_reporter(build_id: build_id)
 
     assert_match "Flaky jobs detected", output
-    assert_match "bin/rspec --seed 1234 ./spec/foo_spec.rb:2", output
+    assert_match "./spec/foo_spec.rb[1:1]", output
     refute_match "Failed examples", output
   end
 end

--- a/test/test_reporter.rb
+++ b/test/test_reporter.rb
@@ -26,11 +26,15 @@ class TestReporter < RSpecQTest
 
   def test_flakey_suite
     build_id = rand_id
-    exec_build("flakey_suite", "", build_id: build_id)
+    worker_id = rand_id
+    exec_build("flakey_suite", "--seed 1234", build_id: build_id, worker_id: worker_id)
     output = exec_reporter(build_id: build_id)
 
     assert_match "Flaky jobs detected", output
-    assert_match "./spec/foo_spec.rb[1:1]", output
+    assert_match "./spec/foo_spec.rb:2 @ #{worker_id}", output
+    assert_match "DISABLE_SPRING=1 DISABLE_BOOTSNAP=1 bin/rspecq --build 1 " \
+        "--worker foo --seed 1234 --max-requeues 0 --fail-fast 1 --reproduction " \
+        "./spec/foo_spec.rb ./spec/foo_spec.rb[1:1] ./spec/foo_spec.rb[1:1]", output
     refute_match "Failed examples", output
   end
 end


### PR DESCRIPTION
Originally, a flaky test would appear in the report by its just example id which is not helpful at all.

Then we merged https://github.com/skroutz/rspecq/commit/9f6816e4f82f6d6da6952e552b2bc0ad777f0d36 which tried to replace the flaky example id with a reproduction command. The command did not work however because the premise was wrong. You see, to correctly reproduce a flaky test you need more than the seed and the test file. You also need all the files the preceded the flaky test, up to the point in time when you reset rspec and the databases. For rspecq, this point in time is the start of a worker.

Both of the above issues are mitigiated:
1. Flaky tests are reported by their example location, which by itself does not offer anything, but at least it shows the developer which test exactly is flaky.
2. Provides a reproduction command for each flaky test, which is the gist.

The reproduction (or rerun) command, consists of the seed and the files originally tested by the worker when the test failed.

## A note regarding the reproduction command

### With RSpec

```
bin/rspec --seed 1234 bar_spec:6 foo_spec.rb bar_spec:4
```

This does not work for two reasons: 
1. When you pass files **and** individual examples, rspec ignores the files. I tried to debug this and it is not easy to understand rspec's code, believe me. Although it seems a bit buggy to me, it does not really matter because
1. It groups individual examples coming from the same file. For example, in the above command, rspec would execute examples `bar_spec:4` and `bar_spec:6` together because they are defined in the same example group.

The above render this option completely unusable, because we want to be able to run the examples **in the exact same order** as they did in the rspecq worker in the ci.

### With RSpecQ

```
bin/rspecq --seed 1234 bar_spec:6 foo_spec.rb bar_spec:4
```

The above does not work either because rspecq uses rspec to group examples by files and then shuffles the files intentionally.

### With RSpecQ and the new `reproduction` flag

We [introduce](https://github.com/skroutz/rspecq/pull/64/commits/a919eba7cebcbb969a8372b4f7ec544b34343d0d) an update to rspecq with which a developer can pass examples and files to rspecq and always get the same result. Internally, rspecq simply publishes the files and examples exactly as given in the command.

The [command](https://github.com/skroutz/rspecq/pull/64/files#diff-61008cc9dbfda4074d20b9ff1230e7144751bc348744ab5e99ce7ff81275f282R35) is included in the report under the flaky tests section.

Its form is the not prettiest, but is not something we can avoid. Also, depending on anyone's needs, it may need tuning. However, most users should be able to use it seemlessly.

The report looks like:

```
Flaky jobs detected (count=1):
  ./spec/foo_spec.rb[1:20:5:1]
```

and will now look like:

```
Flaky jobs detected (count=1):
./spec/foo_spec.rb[3] @ <worker-name>
DISABLE_SPRING=1 DISABLE_BOOTSNAP=1 bin/rspecq --build 1 --worker foo --seed 1234 --max-requeues 0 --fail-fast 1 --reproduction ./spec/foo_spec.rb ./spec/bar_spec.rb[1:1]
```

A dev can run the command above with any build and worker id and will get the failure!

> You need to have a redis running as well.