### PR TITLE
Fix typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ OPTIONS:
 You can set most options using ENV variables:
 
 ```shell
-$ RSPECQ_BUILD=123 RSPECQ_WORKDER=foo1 rspecq spec/
+$ RSPECQ_BUILD=123 RSPECQ_WORKER=foo1 rspecq spec/
 ```
 
 ### Supported ENV variables


### PR DESCRIPTION
This small PR fixes a typo in the README.md regarding RSPECQ_WORKER env variable