### PR TITLE
Switch from `sentry-raven` to `sentry-ruby`

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,8 +110,7 @@ $ RSPECQ_BUILD=123 RSPECQ_WORKER=foo1 rspecq spec/
 
 RSpecQ can optionally emit build events to a
 [Sentry](https://sentry.io) project by setting the
-[`SENTRY_DSN`](https://github.com/getsentry/raven-ruby#raven-only-runs-when-sentry_dsn-is-set)
-environment variable.
+`SENTRY_DSN` environment variable.
 
 This is convenient for monitoring important warnings/errors that may impact
 build times, such as the fact that no previous timings were found and

--- a/bin/rspecq
+++ b/bin/rspecq
@@ -154,6 +154,8 @@ else
   redis_opts[:host] = opts[:redis_host]
 end
 
+Sentry.init if ENV['SENTRY_DSN']
+
 if opts[:report]
   reporter = RSpecQ::Reporter.new(
     build_id: opts[:build],

--- a/lib/rspecq.rb
+++ b/lib/rspecq.rb
@@ -1,5 +1,5 @@
 require "rspec/core"
-require "sentry-raven"
+require "sentry-ruby"
 
 module RSpecQ
   # If a worker haven't executed an example for more than WORKER_LIVENESS_SEC

--- a/lib/rspecq/reporter.rb
+++ b/lib/rspecq/reporter.rb
@@ -150,7 +150,7 @@ module RSpecQ
           spec_file: filename
         }
 
-        Raven.capture_message(
+        Sentry.capture_message(
           "Flaky test in #{filename}",
           level: "warning",
           extra: extra,

--- a/lib/rspecq/worker.rb
+++ b/lib/rspecq/worker.rb
@@ -270,7 +270,7 @@ module RSpecQ
     def log_event(msg, level, additional = {})
       puts msg
 
-      Raven.capture_message(msg, level: level, extra: {
+      Sentry.capture_message(msg, level: level, extra: {
         build: @build_id,
         worker: @worker_id,
         queue: queue.inspect,

--- a/rspecq.gemspec
+++ b/rspecq.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   end
 
   s.add_dependency "redis"
-  s.add_dependency "sentry-raven"
+  s.add_dependency "sentry-ruby"
 
   s.add_development_dependency "minitest"
   s.add_development_dependency "pry-byebug"


### PR DESCRIPTION
As mentioned in #68, `sentry-raven` is [outdated and deprecated](https://github.com/getsentry/sentry-ruby#migrate-from-sentry-raven). The switch to `sentry-ruby` (the new SDK) was very straightforward, so I'm hopeful this can get merged. I tested this and it works perfectly for me.

Thank you for your time!

Fixes #68