### PR TITLE
CI: Add Ruby 3.1, 3.0, but only for latest RSpec

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,14 +13,16 @@ jobs:
       matrix:
         redis-version: [5]
 
-        ruby-version: [2.5]
+        ruby-version:
+          - 3.1
+          - '3.0'  # Quoted in order to stringify to '3.0', not '3'.
+          - 2.5
 
-        rspec-core-version: [
-          3.8.2,
-          3.9.3,
-          3.10.1,
-          3.11.0,
-        ]
+        rspec-core-version:
+          - 3.8.2
+          - 3.9.3
+          - 3.10.1
+          - 3.11.0
 
     services:
       redis:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,8 +14,6 @@ jobs:
         redis-version: [5]
 
         ruby-version:
-          - 3.1
-          - '3.0'  # Quoted in order to stringify to '3.0', not '3'.
           - 2.5
 
         rspec-core-version:
@@ -23,6 +21,11 @@ jobs:
           - 3.9.3
           - 3.10.1
           - 3.11.0
+        include:
+          - ruby-version: 3.1
+            rspec-core-version: 3.11.0
+          - ruby-version: 3.0   # Quoted in order to stringify to '3.0', not '3'.
+            rspec-core-version: 3.11.0
 
     services:
       redis:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,9 +22,11 @@ jobs:
           - 3.10.1
           - 3.11.0
         include:
-          - ruby-version: 3.1
+          - redis-version: 5
+            ruby-version: 3.1
             rspec-core-version: 3.11.0
-          - ruby-version: 3.0   # Quoted in order to stringify to '3.0', not '3'.
+          - redis-version: 5
+            ruby-version: '3.0'   # Quoted in order to stringify to '3.0', not '3'.
             rspec-core-version: 3.11.0
 
     services:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,6 +9,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
 
+    name: "Redis ${{ matrix.redis-version }}, Ruby ${{ matrix.ruby-version }}, RSpec ${{ matrix.rspec-core-version }}"
     strategy:
       matrix:
         redis-version: [5]


### PR DESCRIPTION
This PR extends the build matrix with the two latest Ruby versions.

This also formats a YAML list, to make the GitHub editor not complain about formatting.

Arguable 2.7 could be in there, becoming the oldest build target.