### PR TITLE
reporter: Report unique events to Sentry per spec

### DIFF
--- a/lib/rspecq/reporter.rb
+++ b/lib/rspecq/reporter.rb
@@ -61,7 +61,7 @@ module RSpecQ
       puts summary(@queue.example_failures, @queue.non_example_errors,
         flaky_jobs, humanize_duration(tests_duration))
 
-      flaky_jobs_to_sentry(flaky_jobs, tests_duration, @queue.flaky_failures)
+      flaky_jobs_to_sentry(tests_duration, @queue.flaky_failures)
 
       exit 1 if !@queue.build_successful?
     end
@@ -132,11 +132,15 @@ module RSpecQ
       Time.at(seconds).utc.strftime("%H:%M:%S")
     end
 
-    def flaky_jobs_to_sentry(jobs, build_duration, failures)
-      return if jobs.empty?
+    def flaky_jobs_to_sentry(build_duration, failures)
+      return if failures.empty?
 
-      jobs.each do |job|
+      failures.each do |job, msg|
         filename = job.sub(/\[.+\]/, "")[%r{spec/.+}].split(":")[0]
+        spec_name = msg.split("\n")[1].strip
+        # Use this digest in order to make the Sentry event name unique per spec
+        sha = Digest::SHA1.hexdigest(filename + spec_name)
+        event_message = filename + ' ' + sha
 
         extra = {
           build: @build_id,
@@ -150,11 +154,12 @@ module RSpecQ
 
         tags = {
           flaky: true,
-          spec_file: filename
+          spec_file: filename,
+          spec_sha: sha
         }
 
         Raven.capture_message(
-          "Flaky test in #{filename}",
+          event_message,
           level: "warning",
           extra: extra,
           tags: tags

--- a/lib/rspecq/version.rb
+++ b/lib/rspecq/version.rb
@@ -1,3 +1,3 @@
 module RSpecQ
-  VERSION = "0.7.2-skr8".freeze
+  VERSION = "0.7.2-skr9".freeze
 end


### PR DESCRIPTION
Sentry messages are displayed as issues in the issues stream, with the message serving as the issue's title.
Up until now, the name of the file containing the failing spec was included in the event message, 
thus all failures for each spec file were grouped together under the same event.

With this commit, a SHA1 digest is created for each spec (spec filename+ spec name) and included in the event message, leading to unique Sentry events per spec file.
