### PR TITLE
[chore] security CI/CD workflows sha-pin actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,7 +37,7 @@ jobs:
           - 6379:6379
 
     steps:
-      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
 
       - uses: ruby/setup-ruby@922ebc4c5262cd14e07bb0e1db020984b6c064fe # v1
         env:


### PR DESCRIPTION
In lights of https://skroutz.slack.com/archives/CP43TUJDU/p1742189867715899

We need to SHA PIN all github actions, as a measure for Supply Chain attacks Example: https://github.com/skroutz-internal/yogurt/blob/master/.github/workflows/prod-deploy.yaml#L78

Rationale: https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions?learn=getting_started#using-third-party-actions