### PR TITLE
Utilize workers while the queue is published

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ OPTIONS:
         --redis-url URL              Redis URL to connect to (e.g.: redis://127.0.0.1:6379/0).
         --update-timings             Update the global job timings key with the timings of this build. Note: This key is used as the basis for job scheduling.
         --file-split-threshold N     Split spec files slower than N seconds and schedule them as individual examples.
+        --early-push-max-jobs N      Only emit up to N jobs early
         --graceful-shutdown-signal   Graceful shutdown worker on signal.
         --graceful-shutdown-timeout N SIGKILL worker after N seconds.
         --report                     Enable reporter mode: do not pull tests off the queue; instead print build progress and exit when it's finished.
@@ -100,6 +101,7 @@ $ RSPECQ_BUILD=123 RSPECQ_WORKER=foo1 rspecq spec/
 | `RSPECQ_REDIS` | Redis HOST |
 | `RSPECQ_UPDATE_TIMINGS` | Timings |
 | `RSPECQ_FILE_SPLIT_THRESHOLD` | File split threshold |
+| `RSPECQ_EARLY_PUSH_MAX_JOBS` | Push jobs early up to a certain number |
 | `RSPECQ_GRACEFUL_SHUTDOWN_SIGNAL` | Graceful worker shutdown signal |
 | `RSPECQ_GRACEFUL_SHUTDOWN_TIMEOUT` | Timeout before killing worker |
 | `RSPECQ_REPORT` | Report |

--- a/bin/rspecq
+++ b/bin/rspecq
@@ -148,6 +148,7 @@ opts[:seed] ||= ENV.fetch("RSPECQ_SEED", nil)
 opts[:redis_host] ||= ENV["RSPECQ_REDIS"] || DEFAULT_REDIS_HOST
 opts[:timings] ||= env_set?("RSPECQ_UPDATE_TIMINGS")
 opts[:file_split_threshold] ||= Integer(ENV["RSPECQ_FILE_SPLIT_THRESHOLD"] || 9_999_999)
+opts[:early_push_max_jobs] ||= Integer(ENV["RSPECQ_EARLY_PUSH_MAX_JOBS"]) if ENV["RSPECQ_EARLY_PUSH_MAX_JOBS"]
 opts[:graceful_shutdown_signal] ||= ENV.fetch("RSPECQ_GRACEFUL_SHUTDOWN_SIGNAL", DEFAULT_GRACEFUL_SHUTDOWN_SIGNAL)
 opts[:graceful_shutdown_timeout] ||= Integer(ENV.fetch("RSPECQ_GRACEFUL_SHUTDOWN_TIMEOUT",
   DEFAULT_GRACEFUL_SHUTDOWN_TIMEOUT))
@@ -198,6 +199,7 @@ else
     worker.files_or_dirs_to_run = ARGV if ARGV.any?
     worker.populate_timings = opts[:timings]
     worker.file_split_threshold = opts[:file_split_threshold]
+    worker.early_push_max_jobs = opts[:early_push_max_jobs] if opts[:early_push_max_jobs]
     worker.max_requeues = opts[:max_requeues]
     worker.queue_wait_timeout = opts[:queue_wait_timeout]
     worker.fail_fast = opts[:fail_fast]

--- a/lib/rspecq/queue.rb
+++ b/lib/rspecq/queue.rb
@@ -106,7 +106,7 @@ module RSpecQ
     end
 
     # NOTE: jobs will be processed from head to tail (lpop)
-    def publish(jobs, fail_fast = 0)
+    def push_jobs(jobs, fail_fast = 0)
       time = current_time
       redis.multi do |pipeline|
         pipeline.hset(key_queue_config, "fail_fast", fail_fast)

--- a/lib/rspecq/queue.rb
+++ b/lib/rspecq/queue.rb
@@ -106,13 +106,18 @@ module RSpecQ
     end
 
     # NOTE: jobs will be processed from head to tail (lpop)
-    def push_jobs(jobs, fail_fast = 0)
-      time = current_time
+    # If publish is false, the queue will not be marked as ready
+    # This is handy if we want to push jobs in multiple batches
+    # to utilize workers as soon as possible
+    def push_jobs(jobs, fail_fast = 0, publish: true)
+      time = current_time if publish
+
       redis.multi do |pipeline|
         pipeline.hset(key_queue_config, "fail_fast", fail_fast)
-        pipeline.rpush(key_queue_unprocessed, jobs)
-        pipeline.setnx(key_queue_ready_at, time)
-        pipeline.set(key_queue_status, STATUS_READY)
+        pipeline.rpush(key_queue_unprocessed, jobs) if jobs.any?
+
+        pipeline.setnx(key_queue_ready_at, time) if publish
+        pipeline.set(key_queue_status, STATUS_READY) if publish
       end
 
       jobs.size

--- a/lib/rspecq/worker.rb
+++ b/lib/rspecq/worker.rb
@@ -166,7 +166,7 @@ module RSpecQ
       queue.mark_elected_master_at
 
       if reproduction
-        q_size = queue.publish(files_or_dirs_to_run, fail_fast)
+        q_size = queue.push_jobs(files_or_dirs_to_run, fail_fast)
         log_event(
           "Reproduction mode. Published queue as given (size=#{q_size})",
           "info"
@@ -181,7 +181,7 @@ module RSpecQ
 
       timings = queue.timings
       if timings.empty?
-        q_size = queue.publish(files_to_run.shuffle, fail_fast)
+        q_size = queue.push_jobs(files_to_run.shuffle, fail_fast)
         log_event(
           "No timings found! Published queue in random order (size=#{q_size})",
           "warning"

--- a/lib/rspecq/worker.rb
+++ b/lib/rspecq/worker.rb
@@ -96,7 +96,6 @@ module RSpecQ
       q_size = try_publish_queue!(queue)
       puts "Published queue (size=#{q_size})" if q_size
 
-      queue.wait_until_published(queue_wait_timeout)
       queue.save_worker_seed(@worker_id, seed)
 
       loop do
@@ -190,7 +189,6 @@ module RSpecQ
       end
 
       # prepare jobs to run
-      jobs = []
       slow_files = []
 
       if file_split_threshold
@@ -199,15 +197,21 @@ module RSpecQ
         end.map(&:first) & files_to_run
       end
 
-      if slow_files.any?
-        jobs.concat(files_to_run - slow_files)
-        jobs.concat(files_to_example_ids(slow_files))
-      else
-        jobs.concat(files_to_run)
+      if slow_files.empty?
+        return queue.push_jobs(order_jobs_by_timings(files_to_run), fail_fast)
       end
 
-      jobs = order_jobs_by_timings(jobs)
-      queue.publish(jobs, fail_fast)
+      jobs = order_jobs_by_timings(files_to_run - slow_files)
+      pending = slow_files
+
+      # Push non-slow files first to make sure that workers can start working
+      # TODO we might want push until the default_timing threshold so that we
+      # have a fair scheduling accounting for untimed jobs
+      queue.push_jobs(jobs, fail_fast, publish: false)
+
+      # Populate splitted slow files
+      pending = files_to_example_ids(pending)
+      queue.push_jobs(order_jobs_by_timings(pending), fail_fast)
     end
 
     private

--- a/test/test_helpers.rb
+++ b/test/test_helpers.rb
@@ -10,6 +10,10 @@ module TestHelpers
     SecureRandom.hex(4)
   end
 
+  def rspecq_redis
+    Redis.new(REDIS_OPTS)
+  end
+
   def new_worker(path)
     w = RSpecQ::Worker.new(
       build_id: rand_id,

--- a/test/test_queue.rb
+++ b/test/test_queue.rb
@@ -25,9 +25,9 @@ class TestQueue < RSpecQTest
     assert_failures(["./spec/legit_failure_spec.rb[1:3]"], queue)
   end
 
-  def test_publish_returns_jobs_size
+  def test_push_jobs_returns_jobs_size
     queue = RSpecQ::Queue.new(rand_id, rand_id, REDIS_OPTS)
 
-    assert_equal 2, queue.publish(["job1", "job2"])
+    assert_equal 2, queue.push_jobs(["job1", "job2"])
   end
 end

--- a/test/test_scheduling.rb
+++ b/test/test_scheduling.rb
@@ -136,4 +136,42 @@ class TestScheduling < RSpecQTest
     assert_match RSpecQ::Queue::STATUS_READY, commands.last
   end
 
+  def test_disabled_early_yielding_jobs_before_publishing
+    # 1st run to populate timings so that we trigger the test splitting
+    worker = new_worker("scheduling")
+    worker.populate_timings = true
+    silent { worker.work }
+    assert_queue_well_formed(worker.queue)
+
+    # Setup a thread to monitor Redis commands before triggering a
+    # second run
+    redis_commands = ::Queue.new
+    monitoring_thread = Thread.new do
+      rspecq_redis.monitor do |line|
+        next if line.nil?
+
+        # Select commands #push_jobs uses
+        redis_commands << line if line['"rpush"'] && line[":queue:unprocessed"]
+        redis_commands << line if line['"set"'] && line[RSpecQ::Queue::STATUS_READY]
+      end
+    end
+
+    # 2nd run, the slow file will be split and yielded in a single step
+    # since early_push_max_jobs is 0 (disabled)
+    worker = new_worker("scheduling")
+    worker.file_split_threshold = 0.2
+    worker.early_push_max_jobs = 0 # Disable early yielding!
+    silent { worker.work }
+
+    # Gather redis commands and stop monitoring
+    monitoring_thread.kill
+    monitoring_thread.join
+
+    commands = []
+    commands << redis_commands.shift until redis_commands.empty?
+
+    assert_equal 2, commands.size # Only a single (rpush + ready)
+    assert_match '"rpush"', commands.first
+    assert_match RSpecQ::Queue::STATUS_READY, commands.last
+  end
 end

--- a/test/test_scheduling.rb
+++ b/test/test_scheduling.rb
@@ -47,6 +47,7 @@ class TestScheduling < RSpecQTest
     worker = new_worker("scheduling")
     worker.populate_timings = true
     worker.file_split_threshold = 0.2
+    worker.early_push_max_jobs = 0 # Disable early yielding to ensure a fair scheduling
     silent { worker.try_publish_queue!(worker.queue) }
 
     assert_equal [
@@ -96,4 +97,43 @@ class TestScheduling < RSpecQTest
       "./test/sample_suites/deprecation_warning/spec/foo_spec.rb[1:2]",
     ], worker.queue)
   end
+
+  def test_early_yielding_jobs_before_publishing
+    # 1st run to populate timings so that we trigger the test splitting
+    worker = new_worker("scheduling")
+    worker.populate_timings = true
+    silent { worker.work }
+    assert_queue_well_formed(worker.queue)
+
+    # Setup a thread to monitor Redis commands before triggering a
+    # second run
+    redis_commands = ::Queue.new
+    monitoring_thread = Thread.new do
+      rspecq_redis.monitor do |line|
+        next if line.nil?
+
+        # Select commands #push_jobs uses
+        redis_commands << line if line['"rpush"'] && line[":queue:unprocessed"]
+        redis_commands << line if line['"set"'] && line[RSpecQ::Queue::STATUS_READY]
+      end
+    end
+
+    # 2nd run, the slow file will be split and yielded later
+    worker = new_worker("scheduling")
+    worker.file_split_threshold = 0.2
+    silent { worker.work }
+
+    # Gather redis commands and stop monitoring
+    monitoring_thread.kill
+    monitoring_thread.join
+
+    commands = []
+    commands << redis_commands.shift until redis_commands.empty?
+
+    assert_equal 3, commands.size # 1 yielded rpush + 1 (rpush + ready)
+    assert_match '"rpush"', commands[0]
+    assert_match '"rpush"', commands[1]
+    assert_match RSpecQ::Queue::STATUS_READY, commands.last
+  end
+
 end


### PR DESCRIPTION
Support pushing jobs early on, before file-splitting, to utilize workers while that happens.

In our ~20min CI run, this gives us about 1.5 minute gain.

Solves #93.