### PR TITLE
Measure build times revamp

### DIFF
--- a/lib/rspecq/worker.rb
+++ b/lib/rspecq/worker.rb
@@ -115,7 +115,10 @@ module RSpecQ
         job = queue.reserve_job
 
         # build is finished
-        return if job.nil? && queue.exhausted?
+        if job.nil? && queue.exhausted?
+          queue.try_mark_finished
+          return
+        end
 
         next if job.nil?
 

--- a/lib/rspecq/worker.rb
+++ b/lib/rspecq/worker.rb
@@ -159,6 +159,8 @@ module RSpecQ
     def try_publish_queue!(queue)
       return if !queue.become_master
 
+      queue.mark_elected_master_at
+
       if reproduction
         q_size = queue.publish(files_or_dirs_to_run, fail_fast)
         log_event(

--- a/test/test_helpers/assertions.rb
+++ b/test/test_helpers/assertions.rb
@@ -7,7 +7,12 @@ module TestHelpers
       )
 
       assert queue.published?
-      assert(queue.build_failed_fast? || queue.exhausted?)
+
+      failed_fast = queue.build_failed_fast?
+      exhausted = queue.exhausted?
+      assert(failed_fast || exhausted)
+      assert queue.took_time_secs >= 0 if exhausted
+
       assert_operator heartbeats.size, :>=, 0
       assert(heartbeats.all? { |hb| Time.at(hb.last) <= Time.now })
     end

--- a/test/test_helpers/assertions.rb
+++ b/test/test_helpers/assertions.rb
@@ -11,7 +11,12 @@ module TestHelpers
       failed_fast = queue.build_failed_fast?
       exhausted = queue.exhausted?
       assert(failed_fast || exhausted)
-      assert queue.took_time_secs >= 0 if exhausted
+
+      if exhausted
+        from_elected_master, from_queue_ready = queue.took_times_secs
+        assert(from_elected_master >= 0)
+        assert(from_queue_ready >= 0)
+      end
 
       assert_operator heartbeats.size, :>=, 0
       assert(heartbeats.all? { |hb| Time.at(hb.last) <= Time.now })

--- a/test/test_reporter.rb
+++ b/test/test_reporter.rb
@@ -9,7 +9,7 @@ class TestReporter < RSpecQTest
     assert_match "Total results", output
     assert_match "1 examples (1 jobs)", output
     assert_match "0 failures", output
-    assert_match "execution time", output
+    assert_match "Spec time", output
     refute_match "Failed examples", output
     refute_match "Flaky", output
   end


### PR DESCRIPTION
Reported build times were measured by the reporter, and depended on the time the reporter was started if the reporter was started after the queue was pubished.

The build times are now now based solely on the workers.