### PR TITLE
seed worker's random generation with the seed option

### DIFF
--- a/lib/rspecq/worker.rb
+++ b/lib/rspecq/worker.rb
@@ -98,6 +98,13 @@ module RSpecQ
 
       queue.save_worker_seed(@worker_id, seed)
 
+      # Use `--seed` to deterministically reproduce test failures
+      # related to randomization by passing the same `--seed` value
+      # as the one that triggered the failure.
+      #
+      # We also use the same seed to feed Rspec's `--seed` option.
+      Kernel.srand(seed)
+
       loop do
         # we have to bootstrap this so that it can be used in the first call
         # to `requeue_lost_job` inside the work loop

--- a/test/sample_suites/random_failing/spec/seed_spec.rb
+++ b/test/sample_suites/random_failing/spec/seed_spec.rb
@@ -1,0 +1,3 @@
+RSpec.describe do
+  it { expect(rand(2)).to be_zero }
+end

--- a/test/test_e2e.rb
+++ b/test/test_e2e.rb
@@ -166,6 +166,18 @@ class TestEndToEnd < RSpecQTest
     assert_includes [2, 3], queue.processed_jobs.length
   end
 
+  def test_seed_reproducability
+    initial_outcome = nil
+
+    3.times do |i|
+      queue = exec_build("random_failing", " --max-requeues 0 --seed 1234", build_id: "run-#{i}")
+      outcome = queue.build_successful?
+      initial_outcome ||= outcome
+
+      assert_equal outcome, initial_outcome, "the outcome should be the same for the same seed"
+    end
+  end
+
   def test_graceful_shutdown
     pid, queue = start_worker("rescue_exception",
      "--max-requeues=0 --graceful_shutdown_timeout=5")


### PR DESCRIPTION
So that, rspecq spec runs are reproducible regarding random number generation (`rand()`).