### PR TITLE
do not override file timings with partial timings

### DIFF
--- a/lib/rspecq/queue.rb
+++ b/lib/rspecq/queue.rb
@@ -302,8 +302,10 @@ module RSpecQ
       whole_file_timings = populate_splitted_file_timings(redis_timings)
       return redis_timings if whole_file_timings.empty?
 
-      redis_timings.merge!(whole_file_timings)
-      redis_timings.sort_by { |_j, d| -d }.to_h
+      # Make sure that redis_timings overrides whole_file_timings in case
+      # there are any duplicates
+      whole_file_timings.merge!(redis_timings)
+      whole_file_timings.sort_by { |_j, d| -d }.to_h
     end
 
     # ordered by execution time desc (slowest are in the head)

--- a/test/test_queue.rb
+++ b/test/test_queue.rb
@@ -30,4 +30,17 @@ class TestQueue < RSpecQTest
 
     assert_equal 2, queue.push_jobs(["job1", "job2"])
   end
+
+  def test_timings_reconstruction
+    queue = RSpecQ::Queue.new(rand_id, rand_id, REDIS_OPTS)
+
+    queue.record_build_timing("foo", 42.0)
+    queue.record_build_timing("foo[1]", 1.0)
+
+    queue.update_global_timings
+
+    global_timings = queue.global_timings
+
+    assert_equal 42.0, global_timings["foo"], "File timing should not be overriden"
+  end
 end


### PR DESCRIPTION
When a requeue is executed its timing is recorded. This
triggers the whole-file-timings reconstruction that sums up
examples to deduce the whole file's duration.

So we might end up with a timing for a file that was not splitted
at all!
