### PR TITLE
reporter: report timings of flaky jobs

### DIFF
--- a/lib/rspecq/queue.rb
+++ b/lib/rspecq/queue.rb
@@ -250,6 +250,10 @@ module RSpecQ
       @redis.zadd(key_build_timings, duration, job)
     end
 
+    def job_build_timing(job)
+      @redis.zscore(key_build_timings, job)
+    end
+
     # Persist build timings to the global timings key, so that they can be
     # used for scheduling future builds.
     def update_global_timings(dst = key_timings)

--- a/lib/rspecq/reporter.rb
+++ b/lib/rspecq/reporter.rb
@@ -145,8 +145,13 @@ module RSpecQ
         summary << "\n\n"
         summary << "Flaky jobs detected (count=#{flaky_jobs.count}):\n"
         flaky_jobs.each do |j|
+          job_timing = if (jt = @queue.job_build_timing(j))
+                         humanize_duration(jt.to_i)
+                       else
+                         "---"
+                       end
           summary << RSpec::Core::Formatters::ConsoleCodes.wrap(
-            "#{@queue.job_location(j)} @ #{@queue.failed_job_worker(j)}\n",
+            "#{@queue.job_location(j)} @ #{@queue.failed_job_worker(j)} timing=#{job_timing}\n",
             RSpec.configuration.pending_color
           )
 


### PR DESCRIPTION
Makes it easier to understand the impact on the build time.
