### PR TITLE
worker: do not use example timings for default timing

### DIFF
--- a/lib/rspecq/worker.rb
+++ b/lib/rspecq/worker.rb
@@ -232,12 +232,18 @@ module RSpecQ
       queue.push_jobs(order_jobs_by_timings(pending), fail_fast)
     end
 
+    def default_timing
+      @default_timing ||= begin
+        clean_timings = global_timings.reject { |j, _t| j.include?("[") }
+
+        clean_timings.values[clean_timings.values.size / 2]
+      end
+    end
+
     private
 
     def order_jobs_by_timings(jobs)
       timings = global_timings
-
-      default_timing = timings.values[timings.values.size / 2]
 
       jobs = jobs.each_with_object({}) do |j, h|
         puts "Untimed job: #{j}" if timings[j].nil?

--- a/test/test_queue.rb
+++ b/test/test_queue.rb
@@ -43,4 +43,26 @@ class TestQueue < RSpecQTest
 
     assert_equal 42.0, global_timings["foo"], "File timing should not be overriden"
   end
+
+  def test_default_timing
+    queue = RSpecQ::Queue.new(rand_id, rand_id, REDIS_OPTS)
+
+    # Record file timings
+    queue.record_build_timing("foo", 100.0)
+    queue.record_build_timing("bar", 200.0)
+    queue.record_build_timing("baz", 300.0)
+
+    # Record individual example timings
+    queue.record_build_timing("foo[1]", 1.0)
+    queue.record_build_timing("foo[2]", 2.0)
+    queue.record_build_timing("bar[1]", 3.0)
+    queue.record_build_timing("bar[2]", 4.0)
+    queue.record_build_timing("baz[1]", 5.0)
+    queue.record_build_timing("baz[2]", 6.0)
+
+    queue.update_global_timings
+
+    worker = new_worker("not-existing")
+    assert_equal 200, worker.default_timing, "Default timing should be the median of file timings, not example timings"
+  end
 end


### PR DESCRIPTION
We try to compute the median timing, but the result is skewed by
the examples jobs inserted via the file-splitting mechanism.
