### PR TITLE
mark build status

### DIFF
--- a/lib/rspecq/worker.rb
+++ b/lib/rspecq/worker.rb
@@ -111,7 +111,11 @@ module RSpecQ
         update_heartbeat
 
         return if shutdown?
-        return if queue.build_failed_fast?
+
+        if queue.build_failed_fast?
+          queue.try_mark_finished # build is finished
+          return
+        end
 
         lost, lost_worker = queue.requeue_lost_job
         puts "Requeued lost job: #{lost} from #{lost_worker}" if lost

--- a/test/test_helpers/assertions.rb
+++ b/test/test_helpers/assertions.rb
@@ -11,6 +11,7 @@ module TestHelpers
       failed_fast = queue.build_failed_fast?
       exhausted = queue.exhausted?
       assert(failed_fast || exhausted)
+      assert_includes [RSpecQ::Queue::STATUS_SUCCESS, RSpecQ::Queue::STATUS_FAILURE], queue.status
 
       if exhausted
         from_elected_master, from_queue_ready = queue.took_times_secs


### PR DESCRIPTION
- **mark the job as finished in fail-fast path**
- **mark build status in redis**
