### PR TITLE
record flaky failures

### DIFF
--- a/lib/rspecq/queue.rb
+++ b/lib/rspecq/queue.rb
@@ -247,6 +247,10 @@ module RSpecQ
       @redis.hset(key_failures, example_id, message)
     end
 
+    def record_flaky_failure(example_id, message)
+      @redis.hset(key_flaky_failures, example_id, message)
+    end
+
     # For errors occured outside of examples (e.g. while loading a spec file)
     def record_non_example_error(job, message)
       @redis.hset(key_errors, job, message)
@@ -321,6 +325,10 @@ module RSpecQ
 
     def example_failures
       @redis.hgetall(key_failures)
+    end
+
+    def flaky_failures
+      @redis.hgetall(key_flaky_failures)
     end
 
     def non_example_errors
@@ -554,6 +562,13 @@ module RSpecQ
     # redis: HASH<example_id => error message>
     def key_failures
       key("example_failures")
+    end
+
+    # Contains flaky RSpec example failures.
+    #
+    # redis: HASH<example_id => error message>
+    def key_flaky_failures
+      key("flaky_failures")
     end
 
     # Contains errors raised outside of RSpec examples

--- a/test/test_queue.rb
+++ b/test/test_queue.rb
@@ -22,6 +22,15 @@ class TestQueue < RSpecQTest
        "./spec/legit_failure_spec.rb[1:3]"], queue
     )
 
+    assert_equal 3, queue.flaky_failures.size # legit failure + 2 flakes
+
+    assert_equal [
+      "./spec/flaky_spec.rb[1:1]",
+      "./spec/flaky_spec.rb[1:3]",
+      "./spec/legit_failure_spec.rb[1:3]"
+      ],
+      queue.flaky_failures.keys.sort
+
     assert_failures(["./spec/legit_failure_spec.rb[1:3]"], queue)
   end
 


### PR DESCRIPTION
Record the output of a flaky failure for later inspection.

This a part of an internal patch. I've added a test case, and dropped sentry specific changes.