### PR TITLE
Ruby 4.0.0 ready

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,7 +41,7 @@ jobs:
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
 
-      - uses: ruby/setup-ruby@44511735964dcb71245e7e55f72539531f7bc0eb # v1
+      - uses: ruby/setup-ruby@8aeb6ff8030dd539317f8e1769a044873b56ea71 # v1
         env:
           RSPEC_CORE: ${{ matrix.rspec-core-version }}
         with:

--- a/lib/rspecq/worker.rb
+++ b/lib/rspecq/worker.rb
@@ -87,7 +87,10 @@ module RSpecQ
     end
 
     def shutdown?
-      @shutdown_pipe&.ready?
+      return false if @shutdown_pipe.nil?
+
+      # returns :wait_readable if the supervisor has not signaled shutdown (closed the writer)
+      @shutdown_pipe.read_nonblock(1, exception: false).nil?
     end
 
     def work


### PR DESCRIPTION
- Refactor shutdown mechanics to support ruby 4.0.
- Bump setup-ruby action to support ruby 4.0.0-preview2.
